### PR TITLE
Changed undefined reference to cpu to uptime

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -517,7 +517,7 @@ internals.Monitor.prototype._display = function (events) {
             Hoek.printEvent({
                 timestamp: event.timestamp,
                 tags: ['ops'],
-                data: 'memory: ' + Math.round(event.proc.mem.rss / (1024 * 1024)) + 'M cpu: ' + event.proc.cpu
+                data: 'memory: ' + Math.round(event.proc.mem.rss / (1024 * 1024)) + 'M uptime (seconds): ' + event.proc.uptime
             });
         }
         else if (event.event === 'request') {


### PR DESCRIPTION
event.proc.cpu is no longer available so on a default install I was getting 'cpu: undefined' in the console.  I replaced the reference with event.proc.uptime.
