### PR TITLE
fix link to Hapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a href="https://github.com/spumko"><img src="https://raw.github.com/spumko/spumko/master/images/from.png" align="right" /></a>
 ![good Logo](https://raw.github.com/spumko/good/master/images/good.png)
 
-[**hapi**](https://github.com/walamrtlabs/hapi) process monitoring
+[**hapi**](https://github.com/spumko/hapi) process monitoring
 
 [![Build Status](https://secure.travis-ci.org/spumko/good.png)](http://travis-ci.org/spumko/good)
 


### PR DESCRIPTION
was going to fix typo in Walmart repo, but found that the repo now lives under Spumko
