### PR TITLE
Fix bug to ensure port is defined

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -70,7 +70,7 @@ internals.NetworkMonitor.prototype.reset = function () {
 
 internals.NetworkMonitor.prototype._onRequest = function (request, event, tags) {
 
-    var port = (request.server && request.server.info) ? request.server.info.port : 0;
+    var port = (request.server && request.server.info.port) ? request.server.info.port : 0;
     this._connections[port] = this._connections[port] || request.server._connections;
 
     if (event.tags &&


### PR DESCRIPTION
We're deploying our apps in a Windows environment where we have named pipes as hosts and ports are undefined. 

This particular bug was causing Good to throw errors for some of our apps. This appears to resolve the issue.
