### PR TITLE
Allow all request headers to be optionally logged

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ set `options` to an object with the following optional settings:
   The subscriptions that are available are _ops_, _request_, _log_ and _error_. The destination can be a URI, file or directory path, and _console_.
   Defaults to a console subscriber for _ops_, _request_, and _log_ events. To disable the console output for the server instance pass an empty array
   into the subscribers "console" configuration.
+- `logAllRequestHeaders` - determines if all request headers will be logged. Defaults to _false_
 
 For example:
 

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -33,7 +33,8 @@ internals.defaults = {
     subscribers: null,                              // { console: ['ops', 'request', 'log', 'error'] }
     alwaysMeasureOps: false,                        // Measures ops even if no subscribers
     maxLogSize: 0,                                  // Max bytes allowed to be written to each log file
-    requestTimeout: 60000                           // Number of ms to set timeout for http request to
+    requestTimeout: 60000,                          // Number of ms to set timeout for http request to
+    logAllRequestHeaders: false						// log all headers on request
 };
 
 
@@ -502,6 +503,10 @@ internals.Monitor.prototype._request = function () {
 
         if (self.settings.extendedRequests) {
             event.log = request.getLog();
+        }
+
+        if (self.settings.logAllRequestHeaders) {
+           event.headers = request.headers;
         }
 
         return event;


### PR DESCRIPTION
Sometimes the only way to fully know what a request did is to also log all the headers. With this in place I can fully simulate the original request.
