### PR TITLE
provided option to use x-forwarded-for as remote address

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Applications with multiple server instances, each with its own monitor should on
 as general events are a process-wide facility and will result in duplicated log events. To override some or all of the defaults,
 set `options` to an object with the following optional settings:
 
+- `xforward` - logs remote ip using request.raw.headers['x-forwarded-for'] instead of request.info.remoteAddress. Defaults to _false_. Falls back to request.info.remoteAddress if x-forwarded-for is empty or not set in the request header.
 - `extendedRequests` - determines if the full request log is sent or only the event summary. Defaults to _false_.
 - `httpAgents` - the list of `httpAgents` to report socket information about. Can be a single `http.Agent` or an array of agents objects. Defaults to `Http.globalAgent`.
 - `httpsAgents` - the list of `httpsAgents` to report socket information about. Can be a single `http.Agent` or an array of agents. Defaults to `Https.globalAgent`.

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -23,6 +23,7 @@ var internals = {
 
 
 internals.defaults = {
+    xforward: false,
     opsInterval: 15000,                             // MSec, equal to or greater than 100
     extendedRequests: false,
     requestsEvent: 'tail',                          // Sets the event used by the monitor to listen to finished requests. Other options: 'response'.
@@ -228,7 +229,7 @@ internals.Monitor.prototype._requestHandler = function (request) {
         path: request.path,
         query: request.query,
         source: {
-            remoteAddress: request.info.remoteAddress,
+            remoteAddress: this.xforward && req.headers['x-forwarded-for'] || request.info.remoteAddress,
             userAgent: req.headers['user-agent'],
             referer: req.headers.referer
         },


### PR DESCRIPTION
Providing the option to use X-Forwarded-For as remote client's ip address can be very useful when hapi serves behind nginx or a load balancing web server. It makes more sense to record the 'true' remote ip instead of the proxy server's ip in that kind of scenario.
