### PR TITLE
provided option to use x-forwarded-for as remote address [updated]

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -228,6 +228,7 @@ internals.Monitor.prototype._requestHandler = function (request) {
         query: request.query,
         source: {
             remoteAddress: request.info.remoteAddress,
+            forwardedFor: req.headers['x-forwarded-for'],
             userAgent: req.headers['user-agent'],
             referer: req.headers.referer
         },


### PR DESCRIPTION
Providing the option to use X-Forwarded-For as remote client's ip address can be very useful when hapi serves behind nginx or a load balancing web server. It makes more sense to record the 'true' remote ip instead of the proxy server's ip in that kind of scenario.
