### PR TITLE
add handling for events created before server is started

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -26,7 +26,7 @@ internals.NetworkMonitor.prototype.concurrents = function (callback) {
     var concurrents = {};
     for (var i = 0, il = ports.length; i < il; ++i) {
         var port = ports[i];
-        concurrents[port] = Object.keys(this._connections[port]).length;
+        concurrents[port] = this._connections[port] ? Object.keys(this._connections[port]).length : 0;
     }
 
     return callback(null, concurrents);

--- a/test/network.js
+++ b/test/network.js
@@ -112,6 +112,33 @@ describe('Network Monitor', function () {
         done();
     });
 
+    it('handles undefined connections', function (done) {
+
+        var server = {
+            info: { port: 80 }
+        };
+        var emitter = new Events.EventEmitter();
+        var network = new NetworkMonitor.Monitor(emitter);
+
+        var tags = ['hapi', 'received'];
+        var tagsMap = Hoek.mapToObject(tags);
+        var request = { server: server, url: { pathname: '/' } };
+        emitter.emit('request', request, { tags: tags }, tagsMap);
+        emitter.emit('request', request, { tags: tags }, tagsMap);
+
+        network.requests(function (err, result) {
+
+            expect(result['80'].total).to.equal(2);
+        });
+
+        network.concurrents(function (err, result) {
+
+            expect(result['80']).to.equal(0);
+        });
+
+        done();
+    });
+
     it('tracks requests by server', function (done) {
 
         var server1 = {


### PR DESCRIPTION
with small opsInterval and/or long startups it is possible to hit a situation where the server is not yet started and the _connections structure is undefined.
