### PR TITLE
Cleaned up Process monitoring

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -9,7 +9,7 @@ var Async = require('async');
 var Hoek = require('hoek');
 var System = require('./system');
 var Package = require('../package.json');
-var Process = require('./process');
+var ProcessMonitor = require('./process');
 var Network = require('./network');
 var Schema = require('./schema');
 
@@ -68,8 +68,8 @@ internals.Monitor.prototype.start = function (callback) {
 
     var setupOpsMonitoring = function () {
 
-        var pmonitor = new Process.Monitor();
-        var os = new System.Monitor();
+        var pmonitor = ProcessMonitor;
+        var os = System;
         var network = new Network.Monitor(self._plugin.events);
 
         var asyncOps = {
@@ -77,7 +77,7 @@ internals.Monitor.prototype.start = function (callback) {
             osmem: os.mem,
             osup: os.uptime,
             psup: pmonitor.uptime,
-            psmem: pmonitor.memory,
+            psmem: pmonitor.memoryUsage,
             psdelay: pmonitor.delay,
             requests: network.requests.bind(network),
             concurrents: network.concurrents.bind(network),

--- a/lib/network.js
+++ b/lib/network.js
@@ -16,37 +16,51 @@ module.exports.Monitor = internals.NetworkMonitor = function (events) {
 
 internals.NetworkMonitor.prototype.requests = function (callback) {
 
-    return callback(null, this._requests);
+    var self = this;
+    process.nextTick(function() {
+
+        callback(null, self._requests);
+    });
 };
 
 
 internals.NetworkMonitor.prototype.concurrents = function (callback) {
 
-    var ports = Object.keys(this._connections);
-    var concurrents = {};
-    for (var i = 0, il = ports.length; i < il; ++i) {
-        var port = ports[i];
-        concurrents[port] = this._connections[port] ? Object.keys(this._connections[port]).length : 0;
-    }
+    var self = this;
 
-    return callback(null, concurrents);
+    process.nextTick(function() {
+
+        var ports = Object.keys(self._connections);
+        var concurrents = {};
+        for (var i = 0, il = ports.length; i < il; ++i) {
+            var port = ports[i];
+            concurrents[port] = self._connections[port] ? Object.keys(self._connections[port]).length : 0;
+        }
+
+        return callback(null, concurrents);
+    });
 };
 
 
 internals.NetworkMonitor.prototype.responseTimes = function (callback) {
 
-    var ports = Object.keys(this._responseTimes);
-    var overview = {};
-    for (var i = 0, il = ports.length; i < il; ++i) {
-        var port = ports[i];
-        var count = this._responseTimes[port].count || 1;
-        overview[port] = {
-            avg: this._responseTimes[port].total / count,
-            max: this._responseTimes[port].max
-        };
-    }
+    var self = this;
 
-    return callback(null, overview);
+    process.nextTick(function () {
+
+        var ports = Object.keys(self._responseTimes);
+        var overview = {};
+        for (var i = 0, il = ports.length; i < il; ++i) {
+            var port = ports[i];
+            var count = self._responseTimes[port].count || 1;
+            overview[port] = {
+                avg: self._responseTimes[port].total / count,
+                max: self._responseTimes[port].max
+            };
+        }
+
+        return callback(null, overview);
+    });
 };
 
 
@@ -111,12 +125,14 @@ internals.NetworkMonitor.prototype._onResponse = function (request) {
 
 internals.NetworkMonitor.prototype.sockets = function (httpAgents, httpsAgents, callback) {
 
+    process.nextTick(function() {
 
-    var result = {
-        http: internals.getSocketCount(httpAgents),
-        https: internals.getSocketCount(httpsAgents)
-    };
-    callback(null, result);
+        var result = {
+            http: internals.getSocketCount(httpAgents),
+            https: internals.getSocketCount(httpsAgents)
+        };
+        callback(null, result);
+    });
 };
 
 internals.getSocketCount = function (agents) {

--- a/lib/process.js
+++ b/lib/process.js
@@ -3,25 +3,15 @@
 var Hoek = require('hoek');
 var Utils = require('./utils');
 
-
 // Declare internals
 
 var internals = {};
 
 
-module.exports.Monitor = internals.ProcessMonitor = function () {
-
-    Utils.inheritAsync(internals.ProcessMonitor, process, ['uptime', 'memoryUsage']);
-};
+module.exports = internals;
 
 
-internals.ProcessMonitor.prototype.memory = function (callback) {
-
-    return callback(null, process.memoryUsage());
-};
-
-
-internals.ProcessMonitor.prototype.delay = function (callback) {
+internals.delay = function (callback) {
 
     var bench = new Hoek.Bench();
     setImmediate(function () {
@@ -29,3 +19,9 @@ internals.ProcessMonitor.prototype.delay = function (callback) {
         return callback(null, bench.elapsed());
     });
 };
+
+
+internals.uptime = Utils.makeContinuation(process.uptime);
+
+
+internals.memoryUsage = Utils.makeContinuation(process.memoryUsage);

--- a/lib/system.js
+++ b/lib/system.js
@@ -9,16 +9,21 @@ var Utils = require('./utils');
 var internals = {};
 
 
-module.exports.Monitor = internals.OSMonitor = function () {
+module.exports = internals;
 
-    Utils.inheritAsync(internals.OSMonitor, Os, ['loadavg', 'uptime', 'freemem', 'totalmem', 'cpus']);
-};
-
-
-internals.OSMonitor.prototype.mem = function (callback) {
-
-    callback(null, {
+internals.mem = Utils.makeContinuation(function() {
+    return {
         total: Os.totalmem(),
         free: Os.freemem()
-    });
-};
+    };
+});
+
+internals.loadavg = Utils.makeContinuation(Os.loadavg);
+
+internals.uptime = Utils.makeContinuation(Os.uptime);
+
+internals.freemem = Utils.makeContinuation(Os.freemem);
+
+internals.totalmem = Utils.makeContinuation(Os.totalmem);
+
+internals.cpus = Utils.makeContinuation(Os.cpus);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,30 +5,14 @@
 
 var internals = {};
 
+exports.makeContinuation = function (predicate) {
 
-// Inherits a selected set of methods from an object, wrapping functions in asynchronous syntax and catching errors
+    return function (callback) {
 
-exports.inheritAsync = function (self, obj, keys) {
+        process.nextTick(function () {
 
-    for (var i in obj) {
-
-        if (obj.hasOwnProperty(i)) {
-
-            self.prototype[i] = (function (fn) {
-
-                return function (next) {
-
-                    var result = null;
-                    try {
-                        result = fn();
-                    }
-                    catch (err) {
-                        return next(err);
-                    }
-
-                    return next(null, result);
-                };
-            })(obj[i]);
-        }
-    }
+            var result = predicate();
+            callback(null, result);
+        });
+    };
 };

--- a/test/process.js
+++ b/test/process.js
@@ -23,8 +23,8 @@ describe('Process Monitor', function () {
 
         it('passes the current memory usage to the callback', function (done) {
 
-            var monitor = new ProcessMonitor.Monitor();
-            monitor.memory(function (err, mem) {
+            var monitor = ProcessMonitor;
+            monitor.memoryUsage(function (err, mem) {
 
                 expect(err).not.to.exist;
                 expect(mem).to.exist;
@@ -37,7 +37,7 @@ describe('Process Monitor', function () {
 
         it('passes the current event queue delay to the callback', function (done) {
 
-            var monitor = new ProcessMonitor.Monitor();
+            var monitor = ProcessMonitor;
             monitor.delay(function (err, delay) {
 
                 expect(err).not.to.exist;

--- a/test/system.js
+++ b/test/system.js
@@ -24,7 +24,7 @@ describe('System Monitor', function () {
 
         it('returns an object with the current memory usage', function (done) {
 
-            var monitor = new SystemMonitor.Monitor();
+            var monitor = SystemMonitor;
 
             monitor.mem(function (err, mem) {
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -20,45 +20,18 @@ var it = lab.it;
 
 describe('utils', function () {
 
-    describe('inheritAsync()', function () {
+    describe('makeContinuation()', function () {
 
-        it('successfully creates an object wrapper', function (done) {
+        it('successfully creates a continuation function', function (done) {
 
-            var obj = new Function();
-            var source = {
-                success: function() {
-                    return true;
-                }
-            };
-
-            Utils.inheritAsync(Function, source);
-
-            obj.success(function (error, result) {
-
-                expect(error).to.not.exist;
-                expect(result).to.equal(true);
-
-                done();
+            var method = Utils.makeContinuation(function() {
+                return true;
             });
-        });
 
-        it('successfully returns an error', function (done) {
+            method(function (err, value) {
 
-            var obj = new Function();
-            var source = {
-                success: function() {
-                    throw new Error('not successful');
-                }
-            };
-
-            Utils.inheritAsync(Function, source);
-
-            obj.success(function (error, result) {
-
-                expect(error).to.exist;
-                expect(error.message).to.equal('not successful');
-                expect(result).to.not.exist;
-
+                expect(err).to.not.exist;
+                expect(value).to.be.true;
                 done();
             });
         });


### PR DESCRIPTION
Removed asyc inheritance because `process` was getting in there and we probably shouldn't be attaching things to the process object blindly. It was also more complicated than it needs to be.

Fixes #237 
