### PR TITLE
Added good-console to dependencies since readme states it is included

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "async": "0.9.x",
+    "good-console": "2.x.x",
     "good-reporter": "3.x.x",
     "hoek": "2.x.x",
     "joi": "4.x.x",


### PR DESCRIPTION
Either this or update readme to manually install `good-console`
