### PR TITLE
Added toJSON function to error object

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -205,6 +205,16 @@ internals.Monitor.prototype._errorHandler = function (request, error) {
         error: error
     };
 
+    event.toJSON = function () {
+
+        var errObject = this.error;
+        this.error = {
+            message: errObject.message,
+            stack: errObject.stack
+        };
+        return this;
+    };
+
     this.emit('report', 'error', event);
 };
 

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -716,7 +716,7 @@ describe('good', function () {
                 method: Joi.string().required(),
                 pid: Joi.number().integer().required(),
                 error: Joi.object().required()
-            }).unknown(false);
+            }).unknown();
 
             var consoleError = console.error;
             console.error = Hoek.ignore;
@@ -737,6 +737,11 @@ describe('good', function () {
                         expect(function () {
                             Joi.assert(event, schema);
                         }).to.not.throw();
+
+                        var parse = JSON.parse(JSON.stringify(event));
+
+                        expect(parse.error).to.exist();
+                        expect(parse.error.stack).to.exist();
 
                         console.error = consoleError;
 


### PR DESCRIPTION
Closes #276

Because we attach error directly, which can't be stringified, add a custom `toJSON` method to step around the problem.
