### PR TITLE
Changed event for incoming request.

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -11,25 +11,25 @@ module.exports.Monitor = internals.NetworkMonitor = function (server) {
     this._responseTimes = {};
     this._server = server;
 
-    this._server.ext('onRequest', this._onRequest.bind(this));
+    this._server.on('request-internal', this._onRequest.bind(this));
     this._server.on('response', this._onResponse.bind(this));
 };
 
 
-internals.NetworkMonitor.prototype._onRequest = function (request, reply) {
+internals.NetworkMonitor.prototype._onRequest = function (request, event, tags) {
 
     var self = this;
     var port = request.connection.info.port;
 
-    this._requests[port] = this._requests[port] || { total: 0, disconnects: 0, statusCodes: {} };
-    this._requests[port].total++;
+    if (tags.received) {
+        this._requests[port] = this._requests[port] || { total: 0, disconnects: 0, statusCodes: {} };
+        this._requests[port].total++;
 
-    request.once('disconnect', function () {
+        request.once('disconnect', function () {
 
-        self._requests[port].disconnects++;
-    });
-
-    return reply.continue();
+            self._requests[port].disconnects++;
+        });
+    }
 };
 
 
@@ -64,11 +64,7 @@ internals.NetworkMonitor.prototype.reset = function () {
 
 internals.NetworkMonitor.prototype.requests = function (callback) {
 
-    var self = this;
-    process.nextTick(function() {
-
-        callback(null, self._requests);
-    });
+    callback(null, this._requests);
 };
 
 
@@ -96,36 +92,29 @@ internals.NetworkMonitor.prototype.concurrents = function (callback) {
 
 internals.NetworkMonitor.prototype.responseTimes = function (callback) {
 
-    var self = this;
 
-    process.nextTick(function () {
+    var ports = Object.keys(this._responseTimes);
+    var overview = {};
+    for (var i = 0, il = ports.length; i < il; ++i) {
+        var port = ports[i];
+        var count = Hoek.reach(this, '_responseTimes.' + port + '.count', { default: 1});
+        overview[port] = {
+            avg: this._responseTimes[port].total / count,
+            max: this._responseTimes[port].max
+        };
+    }
 
-        var ports = Object.keys(self._responseTimes);
-        var overview = {};
-        for (var i = 0, il = ports.length; i < il; ++i) {
-            var port = ports[i];
-            var count = Hoek.reach(self, '_responseTimes.' + port + '.count', { default: 1});
-            overview[port] = {
-                avg: self._responseTimes[port].total / count,
-                max: self._responseTimes[port].max
-            };
-        }
-
-        return callback(null, overview);
-    });
+    return callback(null, overview);
 };
 
 
 internals.NetworkMonitor.prototype.sockets = function (httpAgents, httpsAgents, callback) {
 
-    process.nextTick(function() {
-
-        var result = {
-            http: internals.getSocketCount(httpAgents),
-            https: internals.getSocketCount(httpsAgents)
-        };
-        callback(null, result);
-    });
+    var result = {
+        http: internals.getSocketCount(httpAgents),
+        https: internals.getSocketCount(httpsAgents)
+    };
+    callback(null, result);
 };
 
 


### PR DESCRIPTION
Because the "onRequest" extension point could be side-stepped by an earlier "onRequest" extension point and cause downstream impacts, I changed to listen for the "request-internal" event because I think it happens earlier in the life cycle and can't be interrupted.

I also removed a few unnecessary `process.nextTick` calls. 

Closes #285