### PR TITLE
Created filter transform stream and tests.

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,0 +1,90 @@
+var Stream = require('stream');
+var Hoek = require('hoek');
+
+var internals = {};
+
+internals.GoodTransform = module.exports = function (events, options) {
+
+    options = options || {};
+    options.objectMode = true;
+
+    if (!(this instanceof internals.GoodTransform)) {
+        return new internals.GoodTransform(events, options);
+    }
+
+    Stream.Transform.call(this, options);
+    this._good = {
+        subscription: internals.GoodTransform.subscription(events)
+    };
+};
+
+
+Hoek.inherits(internals.GoodTransform, Stream.Transform);
+
+
+internals.GoodTransform.prototype._transform = function (data, enc, next) {
+
+    if (internals.GoodTransform.filter(this._good.subscription, data.event, data.tags)) {
+        this.push(data);
+    }
+    next(null);
+};
+
+
+// events hash of events and tags
+internals.GoodTransform.subscription = function (events) {
+
+    var result = Object.create(null);
+    var subs = Object.keys(events);
+
+    for (var i = 0, il = subs.length; i < il; ++i) {
+        var key = subs[i].toLowerCase();
+        var filter = events[key];
+        var tags = Array.isArray(filter) ? filter : [];
+
+        if (filter && filter !== '*') {
+            tags = tags.concat(filter);
+        }
+
+        // Force everything to be a string
+        for (var j = 0, jl = tags.length; j < jl; ++j) {
+            tags[j] = '' + tags[j];
+        }
+
+        result[key] = tags;
+    }
+    return result;
+};
+
+// subscription - results of subscription function
+// events - event name
+// tags - array of string tags associated with the event
+internals.GoodTransform.filter = function (subscription, event, tags) {
+
+    tags = tags || [];
+
+    var subEventTags = subscription[event];
+
+    // If we aren't interested in this event, break
+    if (!subEventTags) {
+        return false;
+    }
+
+    // If it's an empty array, we do not want to do any filtering
+    if (subEventTags.length === 0) {
+        return true;
+    }
+
+    // Check event tags to see if one of them is in this reports list
+    if (Array.isArray(tags)) {
+        var result = false;
+        for (var i = 0, il = tags.length; i < il; ++i) {
+            var eventTag = tags[i];
+            result = result || subEventTags.indexOf(eventTag) > -1;
+        }
+
+        return result;
+    }
+
+    return false;
+};

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -34,6 +34,9 @@ internals.GoodTransform.prototype._transform = function (data, enc, next) {
 // events hash of events and tags
 internals.GoodTransform.subscription = function (events) {
 
+    // Because we are attaching unrestricted keys from the user to result
+    // we want to null the prototype to prevent issues with "hasOwnPropery" or
+    // other built in keys to Object.
     var result = Object.create(null);
     var subs = Object.keys(events);
 

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -1,0 +1,218 @@
+// Load modules
+
+var Stream = require('stream');
+
+var Code = require('code');
+var Hoek = require('hoek');
+var Lab = require('lab');
+
+var GoodTransform = require('../lib/reporter');
+
+var lab = exports.lab = Lab.script();
+var expect = Code.expect;
+var describe = lab.describe;
+var it = lab.it;
+
+describe('GoodTransform', function () {
+
+    describe('subscription()', function () {
+
+        it('converts *, null, undefined, 0, and false to an empty array, indicating all tags are acceptable', function (done) {
+
+            var tags = ['*', null, undefined, false, 0];
+            for (var i = 0, il = tags.length; i < il; ++i) {
+
+                var result = GoodTransform.subscription({
+                    error: tags[i]
+                });
+
+                expect(result.error).to.deep.equal([]);
+            }
+
+            done();
+        });
+
+        it('converts a single tag to an array', function (done) {
+
+            var result = GoodTransform.subscription({
+                error: 'hapi'
+            });
+
+            expect(result.error).to.deep.equal(['hapi']);
+            done();
+        });
+    });
+
+    describe('filter()', function () {
+
+        it('returns true if this reporter should report this event type', function (done) {
+
+            var subscription = GoodTransform.subscription({
+                log: '*'
+            });
+
+            expect(GoodTransform.filter(subscription, 'log', ['request', 'server', 'error', 'hapi'])).to.be.true();
+
+            done();
+        });
+
+        it('returns false if this report should not report this event type', function (done) {
+
+            var subscription = GoodTransform.subscription({
+                log: '*'
+            });
+
+            expect(GoodTransform.filter(subscription, 'ops', ['*'])).to.be.false();
+
+            done();
+        });
+
+        it('returns true if the event is matched, but there are not any tags with the data', function (done) {
+
+            var subscription = GoodTransform.subscription({
+                log: '*'
+            });
+
+            expect(GoodTransform.filter(subscription, 'log')).to.be.true();
+
+            done();
+        });
+
+        it('returns false if the subscriber has tags, but the matched event does not have any', function (done) {
+
+            var subscription = GoodTransform.subscription({
+                error: 'db'
+            });
+
+            expect(GoodTransform.filter(subscription, 'error', [])).to.be.false();
+
+            done();
+        });
+
+        it('returns true if the event and tag match', function (done) {
+
+            var subscription = GoodTransform.subscription({
+                error: ['high', 'medium', 'log']
+            });
+
+            expect(GoodTransform.filter(subscription, 'error', ['hapi', 'high', 'db', 'severe'])).to.be.true();
+            done();
+        });
+
+        it('returns false by default', function (done) {
+
+            var subscription = GoodTransform.subscription({
+                request: 'hapi'
+            });
+
+            expect(GoodTransform.filter(subscription, 'request')).to.be.false();
+            done();
+        });
+
+        it('returns false if "tags" is not an array', function (done) {
+
+            var subscription = GoodTransform.subscription({
+                request: 'hapi'
+            });
+
+            expect(GoodTransform.filter(subscription, 'request', 'hapi')).to.be.false();
+            done();
+        });
+    });
+
+    it('allows construction with "new"', function (done) {
+
+        var stream = new GoodTransform({
+            request: '*'
+        });
+
+        expect(stream._good.subscription).to.have.length(1);
+        done();
+    });
+
+    it('allows construction without "new"', function (done) {
+
+        var stream = GoodTransform({
+            request: '*',
+            ops: '*'
+        });
+
+        expect(stream._good.subscription).to.have.length(2);
+        done();
+    });
+
+    it('does not forward events if "filter()" is false', function (done) {
+
+        var stream = GoodTransform({
+            request: '*'
+        });
+        var result = [];
+
+        stream.on('data', function (data) {
+
+            result.push(data);
+        });
+
+        stream.on('end', function () {
+
+            expect(result).to.deep.equal([{
+                event: 'request',
+                id: 1
+            }]);
+            done();
+        });
+
+        var read = new Stream.Readable({ objectMode: true });
+        read._read = Hoek.ignore;
+
+        read.pipe(stream);
+
+        read.push({ event: 'request', id: 1});
+        read.push({ event: 'ops', id: 2 });
+        read.push(null);
+    });
+
+    it('remains open as long as the read stream does not end it', function (done) {
+
+        var stream = GoodTransform({
+            request: '*'
+        });
+        var result = [];
+
+        stream.on('data', function (data) {
+
+            result.push(data);
+        });
+
+        stream.on('end', function () {
+
+            expect(result).to.deep.equal([{
+                event: 'request',
+                id: 1
+            }]);
+            done();
+        });
+
+        var read = new Stream.Readable({ objectMode: true });
+        read._read = Hoek.ignore;
+
+        read.pipe(stream);
+
+        read.push({ event: 'request', id: 1});
+        read.push({ event: 'request', id: 2 });
+
+        setTimeout(function () {
+
+            read.push({ event: 'request', id: 3});
+            read.push({ event: 'request', id: 4});
+
+            expect(result).to.deep.equal([
+                { event: 'request', id: 1},
+                { event: 'request', id: 2},
+                { event: 'request', id: 3},
+                { event: 'request', id: 4}
+            ]);
+            done();
+        }, 500);
+    });
+});


### PR DESCRIPTION
Part one of new version. The idea is that when the reporters are started, they will receive the main good read stream and will be passed in this interface. That way, the reporters won't need to reference to any other modules. In the start function, the reports will create their own data pipeline and can use this one to do handle the event filtering. It also has two static methods on it as well in case the reporter doesn't want to implement itself as a stream.

Related to #292 