### PR TITLE
applyFilter: handle empty payloads

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,6 +87,8 @@ exports.GreatResponse = function (request, options, filterRules) {
 
     var applyFilter = function (data) {
 
+        if(!data || Object.keys(data).length === 0) return;
+        
         Traverse(data).forEach(function (value) {
 
             if (this.isLeaf) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,11 +87,11 @@ exports.GreatResponse = function (request, options, filterRules) {
 
     var applyFilter = function (data) {
 
-        if(!(data && typeof data === 'object' && Object.keys(data).length > 0)) {
-            return;
-        }
-        
         Traverse(data).forEach(function (value) {
+
+            if (this.isRoot) {
+                return;
+            }
 
             if (this.isLeaf) {
                 if (filterRules[this.key] || filterRules[this.parent.key]) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,7 +87,9 @@ exports.GreatResponse = function (request, options, filterRules) {
 
     var applyFilter = function (data) {
 
-        if(!data || Object.keys(data).length === 0) return;
+        if(!(data && typeof data === 'object' && Object.keys(data).length > 0)) {
+            return;
+        }
         
         Traverse(data).forEach(function (value) {
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -66,9 +66,9 @@ describe('utils', function () {
             };
 
             var options = {
-                'requestHeaders': true,
-                'requestPayload': true,
-                'responsePayload': true
+                requestHeaders: true,
+                requestPayload: true,
+                responsePayload: true
             };
 
             var request = {
@@ -112,17 +112,23 @@ describe('utils', function () {
 
         it('handles empty request payloads', function (done) {
 
-            generateGreatResponse(null, {message: 'test'});
-            generateGreatResponse({}, {message: 'test'});
-            generateGreatResponse(undefined, {message: 'test'});
+            var sampleResponsePayload = { message: 'test' };
+            generateGreatResponse(null, sampleResponsePayload);
+            generateGreatResponse({}, sampleResponsePayload);
+            generateGreatResponse(undefined, sampleResponsePayload);
+            generateGreatResponse('string payload', sampleResponsePayload);
+            generateGreatResponse('', sampleResponsePayload);
             done();
         });
 
         it('handles empty response payloads', function (done) {
 
-            generateGreatResponse({message: 'test'}, null);
-            generateGreatResponse({message: 'test'}, {});
-            generateGreatResponse({message: 'test'}, undefined);
+            var sampleRequestPayload = { message: 'test' };
+            generateGreatResponse(sampleRequestPayload, null);
+            generateGreatResponse(sampleRequestPayload, {});
+            generateGreatResponse(sampleRequestPayload, undefined);
+            generateGreatResponse(sampleRequestPayload, 'string payload');
+            generateGreatResponse(sampleRequestPayload, '');
             done();
         });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -61,6 +61,7 @@ describe('utils', function () {
     describe('GreatResponse()', function () {
 
         var generateGreatResponse = function (requestPayload, responsePayload) {
+
             var filterRules = {
                 password: 'censor'
             };
@@ -104,6 +105,7 @@ describe('utils', function () {
                     source: responsePayload
                 },
                 getLog: function () {
+
                     return {};
                 }
             };

--- a/test/utils.js
+++ b/test/utils.js
@@ -57,4 +57,74 @@ describe('utils', function () {
             done();
         });
     });
+
+    describe('GreatResponse()', function () {
+
+        var generateGreatResponse = function (requestPayload, responsePayload) {
+            var filterRules = {
+                password: 'censor'
+            };
+
+            var options = {
+                'requestHeaders': true,
+                'requestPayload': true,
+                'responsePayload': true
+            };
+
+            var request = {
+                id: '1429974169154:localhost:10578:i8x5ousn:10000',
+                raw: {
+                    req: {
+                        headers: {
+                            'user-agent': 'Paw/2.2.1 (Macintosh; OS X/10.10.3) GCDHTTPRequest'
+                        }
+                    },
+                    res: {
+                        statusCode: 200
+                    }
+                },
+                info: {
+                    received: 1429974169154,
+                    remoteAddress: '127.0.0.1'
+                },
+                method: 'POST',
+                path: '/',
+                query: {},
+                responseTime: 123,
+                connection: {
+                    settings: {
+                        labels: []
+                    },
+                    info: {
+                        uri: 'http://localhost:3000'
+                    }
+                },
+                payload: requestPayload,
+                response: {
+                    source: responsePayload
+                },
+                getLog: function () {
+                    return {};
+                }
+            };
+            return new Utils.GreatResponse(request, options, filterRules);
+        };
+
+        it('handles empty request payloads', function (done) {
+
+            generateGreatResponse(null, {message: 'test'});
+            generateGreatResponse({}, {message: 'test'});
+            generateGreatResponse(undefined, {message: 'test'});
+            done();
+        });
+
+        it('handles empty response payloads', function (done) {
+
+            generateGreatResponse({message: 'test'}, null);
+            generateGreatResponse({message: 'test'}, {});
+            generateGreatResponse({message: 'test'}, undefined);
+            done();
+        });
+
+    });
 });


### PR DESCRIPTION
Fixes #337. This handles the case when a payload is null (e.g., not posted with a `POST` method or masked by Hapi in case of `GET` method).

By the way: is it correct that Hapi passes null for the payload when a `GET` method is performed?