### PR TITLE
fixes error when response is null

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -141,7 +141,7 @@ exports.GreatResponse = function (request, options, filterRules) {
         this.requestPayload = request.payload;
     }
 
-    if (options.responsePayload) {
+    if (options.responsePayload && request.response) {
         this.responsePayload = request.response.source;
     }
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -60,7 +60,7 @@ describe('utils', function () {
 
     describe('GreatResponse()', function () {
 
-        var generateGreatResponse = function (requestPayload, responsePayload) {
+        var generateGreatResponse = function (requestPayload, responsePayload, nullResponse) {
 
             var filterRules = {
                 password: 'censor'
@@ -101,7 +101,7 @@ describe('utils', function () {
                     }
                 },
                 payload: requestPayload,
-                response: {
+                response: nullResponse ? null : {
                     source: responsePayload
                 },
                 getLog: function () {
@@ -131,6 +131,7 @@ describe('utils', function () {
             generateGreatResponse(sampleRequestPayload, undefined);
             generateGreatResponse(sampleRequestPayload, 'string payload');
             generateGreatResponse(sampleRequestPayload, '');
+            generateGreatResponse(sampleRequestPayload, null, true);
             done();
         });
 


### PR DESCRIPTION
This is related to #285 and #303. It looks like this part of the code was forgotten in the fix, and we are still seeing errors in 5.1.2.