### PR TITLE
Update wreck dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "items": "1.x.x",
     "joi": "6.x.x",
     "traverse": "0.6.6",
-    "wreck": "5.5.x"
+    "wreck": "6.x.x"
   },
   "peerDependencies": {
     "hapi": ">= 8.x.x"


### PR DESCRIPTION
Wreck has released 6.0.0 - this PR updates the good wreck dependency otherwise you end up with multiple wreck versions in your node_modules folder and lose your wreck logs because of the whole singleton thing.