### PR TITLE
Enforce reporter interface. Stash reporter instance & metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ When creating a custom good reporter, it needs to implement the following interf
         - `key` - one of the supported good events or any of the `extensions` events that this reporter should listen for
         - `value` - a single string or an array of strings to filter incoming events. "\*" indicates no filtering. `null` and `undefined` are assumed to be "\*"
     - `config` - an implementation specific configuration value used to instantiate the reporter
+- An `attributes` key set on the constructor function must be an object with a `name` key set to a string that identifies the reporter. `name.pkg` is also acceptable in the style of Hapi plugins.
 - An `init` method with the following signature `function init (readstream, emitter, callback)` where:
     - `readstream` - the incoming [readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) from good. This stream is always in `objectMode`.
     - `emitter` - the good event emitter. The `emitter` will emit the following events:
@@ -292,5 +293,9 @@ GoodReporterExample.prototype.init = function (readstream, emitter, callback) {
         console.log('some clean up logic.');
     });
     callback();
+}
+
+GoodReporterExample.attributes = {
+    name: 'good-reporter-example'
 }
 ```

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -125,29 +125,37 @@ internals.Monitor.prototype.start = function (callback) {
 
     Items.serial(this.settings.reporters, function (item, next) {
 
-        // If the supply a path or module node, try to load it
-        if (typeof item.reporter === 'string') {
-            item.reporter = require(item.reporter);
-        }
+        var reporter;
 
+        // Use hint of reporter index or upgrade to reporter name if present
         var errorHint = self.settings.reporters.length > 1 ? '(' + reportersIndex++ + ')' : '';
-
-        // Ensure reporter has name. If valid name update error hint to reporter name.
         var reporterName = Hoek.reach(item, 'reporter.attributes.name') || Hoek.reach(item, 'reporter.attributes.pkg.name');
 
-        Hoek.assert(typeof reporterName === 'string' && reporterName.length > 0,
-            'reporter missing valid name attribute', errorHint);
+        if (typeof reporterName === 'string' && reporterName.length > 0) {
+            errorHint = '(' + reporterName + ')';
+        }
 
-        errorHint = '(' + reporterName + ')';
+        // If it has a reporter constructor, then create a new one, otherwise, assume it is
+        // a valid pre-constructed reporter
+        if (item.reporter) {
 
-        Hoek.assert(typeof item.reporter === 'function', 'reporter must be a constructor function ', errorHint);
-        Hoek.assert(typeof item.events === 'object', 'reporter must specify events to filter on', errorHint);
+            // If the supply a path or module node, try to load it
+            if (typeof item.reporter === 'string') {
+                item.reporter = require(item.reporter);
+            }
 
-        var Reporter = item.reporter;
-        var reporter = new Reporter(item.events, item.config);
+            Hoek.assert(typeof item.reporter === 'function', 'reporter key must be a constructor function', errorHint);
+            Hoek.assert(typeof item.events === 'object', 'reporter must specify events to filter on', errorHint);
+
+            var Reporter = item.reporter;
+
+            reporter = new Reporter(item.events, item.config);
+        }
+        else {
+            reporter = item;
+        }
 
         Hoek.assert(reporter.init, 'Every reporter object must have an init method', errorHint);
-
         reporter.init(self._dataStream, self, next);
     }, function (error) {
 

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -125,32 +125,28 @@ internals.Monitor.prototype.start = function (callback) {
 
     Items.serial(this.settings.reporters, function (item, next) {
 
-        var hint = self.settings.reporters.length > 1 ? '(' + reportersIndex++ + ')' : '';
-
         // If the supply a path or module node, try to load it
         if (typeof item.reporter === 'string') {
             item.reporter = require(item.reporter);
         }
 
-        Hoek.assert(typeof item.reporter === 'function', 'reporter must be a constructor function ', hint);
+        var errorHint = self.settings.reporters.length > 1 ? '(' + reportersIndex++ + ')' : '';
 
-        var attributes = item.reporter.attributes;
-        Hoek.assert(attributes && typeof attributes === 'object', 'reporter constructor missing attributes object', hint);
+        // Ensure reporter has name. If valid name update error hint to reporter name.
+        var reporterName = Hoek.reach(item, 'reporter.attributes.name') || Hoek.reach(item, 'reporter.attributes.pkg.name');
 
-        var metadata = {
-            name: attributes.name || Hoek.reach(attributes, 'pkg.name'),
-            version: attributes.version || Hoek.reach(attributes, 'pkg.version') || '0.0.0'
-        };
+        Hoek.assert(typeof reporterName === 'string' && reporterName.length > 0,
+            'reporter missing valid name attribute', errorHint);
 
-        Hoek.assert(metadata.name, 'reporter attributus missing name', hint);
-        Hoek.assert(typeof item.events === 'object', 'reporter must specify events to filter on');
+        errorHint = '(' + reporterName + ')';
+
+        Hoek.assert(typeof item.reporter === 'function', 'reporter must be a constructor function ', errorHint);
+        Hoek.assert(typeof item.events === 'object', 'reporter must specify events to filter on', errorHint);
 
         var Reporter = item.reporter;
         var reporter = new Reporter(item.events, item.config);
-        Hoek.assert(reporter.init, 'Every reporter object must have an init method');
 
-        item.instance = reporter;
-        item.metadata = metadata;
+        Hoek.assert(reporter.init, 'Every reporter object must have an init method', errorHint);
 
         reporter.init(self._dataStream, self, next);
     }, function (error) {

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -121,31 +121,37 @@ internals.Monitor.prototype.start = function (callback) {
         };
     };
 
+    var reportersIndex = 0;
+
     Items.serial(this.settings.reporters, function (item, next) {
 
-        var reporter;
+        var hint = self.settings.reporters.length > 1 ? '(' + reportersIndex++ + ')' : '';
 
-        // If it has a reporter constructor, then create a new one, otherwise, assume it is
-        // a valid pre-constructed reporter
-        if (item.reporter) {
-
-            // If the supply a path or module node, try to load it
-            if (typeof item.reporter === 'string') {
-                item.reporter = require(item.reporter);
-            }
-
-            Hoek.assert(typeof item.reporter === 'function', 'reporter key must be a constructor function');
-            Hoek.assert(typeof item.events === 'object', 'reporter must specify events to filter on');
-
-            var Reporter = item.reporter;
-
-            reporter = new Reporter(item.events, item.config);
-        }
-        else {
-            reporter = item;
+        // If the supply a path or module node, try to load it
+        if (typeof item.reporter === 'string') {
+            item.reporter = require(item.reporter);
         }
 
+        Hoek.assert(typeof item.reporter === 'function', 'reporter must be a constructor function ', hint);
+
+        var attributes = item.reporter.attributes;
+        Hoek.assert(attributes && typeof attributes === 'object', 'reporter constructor missing attributes object', hint);
+
+        var metadata = {
+            name: attributes.name || Hoek.reach(attributes, 'pkg.name'),
+            version: attributes.version || Hoek.reach(attributes, 'pkg.version') || '0.0.0'
+        };
+
+        Hoek.assert(metadata.name, 'reporter attributus missing name', hint);
+        Hoek.assert(typeof item.events === 'object', 'reporter must specify events to filter on');
+
+        var Reporter = item.reporter;
+        var reporter = new Reporter(item.events, item.config);
         Hoek.assert(reporter.init, 'Every reporter object must have an init method');
+
+        item.instance = reporter;
+        item.metadata = metadata;
+
         reporter.init(self._dataStream, self, next);
     }, function (error) {
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -5,11 +5,18 @@ module.exports = internals.Reporter = function (events, config, datahandler) {
     this.events = events;
     this.messages = [];
     this.handler = datahandler || function () {};
+
+    // Properties to assert against
+    this.initHitCount = 0;
+    this.emitters = [];
 };
 
 internals.Reporter.prototype.init = function (stream, emitter, callback) {
 
     var self = this;
+
+    this.initHitCount++;
+    this.emitters.push(emitter);
 
     stream.on('data', function (data) {
 
@@ -25,4 +32,9 @@ internals.Reporter.prototype.init = function (stream, emitter, callback) {
     });
 
     callback();
+};
+
+internals.Reporter.attributes = {
+    name: 'good-reporter',
+    version: '1.0.0'
 };

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,40 +1,46 @@
 var internals = {};
 
-module.exports = internals.Reporter = function (events, config, datahandler) {
+module.exports.getTestReporter = function () {
 
-    this.events = events;
-    this.messages = [];
-    this.handler = datahandler || function () {};
+    var Reporter = function (events, config, datahandler) {
 
-    // Properties to assert against
-    this.initHitCount = 0;
-    this.emitters = [];
-};
+        this.events = events;
+        this.messages = [];
+        this.handler = datahandler || function () {};
 
-internals.Reporter.prototype.init = function (stream, emitter, callback) {
+        // Properties to assert against
+        this.initHitCount = 0;
+        this.emitters = [];
 
-    var self = this;
+        Reporter.instance = this;
+    };
 
-    this.initHitCount++;
-    this.emitters.push(emitter);
+    Reporter.prototype.init = function (stream, emitter, callback) {
 
-    stream.on('data', function (data) {
+        var self = this;
 
-        if (self.events[data.event]) {
-            self.messages.push(data);
-            self.handler(data);
-        }
-    });
+        this.initHitCount++;
+        this.emitters.push(emitter);
 
-    emitter.once('stop', function () {
+        stream.on('data', function (data) {
 
-        self.stopped = true;
-    });
+            if (self.events[data.event]) {
+                self.messages.push(data);
+                self.handler(data);
+            }
+        });
 
-    callback();
-};
+        emitter.once('stop', function () {
 
-internals.Reporter.attributes = {
-    name: 'good-reporter',
-    version: '1.0.0'
+            self.stopped = true;
+        });
+
+        callback();
+    };
+
+    Reporter.attributes = {
+        name: 'test-reporter'
+    };
+
+    return Reporter;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@ var Wreck = require('wreck');
 // Done for testing because Wreck is a singleton and every test run ads one event to it
 Wreck.setMaxListeners(0);
 
-var GoodReporter = require('./helper');
+var Helper = require('./helper');
 
 
 // Declare internals
@@ -40,8 +40,9 @@ describe('Plugin', function () {
             httpsAgents: new Https.Agent()
         };
 
+        var Reporter = Helper.getTestReporter();
         options.reporters = [{
-            reporter: GoodReporter,
+            reporter: Reporter,
             events: { ops: '*' }
         }];
 
@@ -56,7 +57,7 @@ describe('Plugin', function () {
 
             server.plugins.good.monitor.once('ops', function (event) {
 
-                var one = plugin.options.reporters[0].instance;
+                var one = Reporter.instance;
 
                 expect(event.osload).to.exist();
                 expect(one.messages).to.have.length(1);
@@ -97,7 +98,7 @@ describe('Plugin', function () {
         };
 
         options.reporters = [{
-            reporter: GoodReporter,
+            reporter: Helper.getTestReporter(),
             events: { ops: '*' }
         }];
 
@@ -161,8 +162,9 @@ describe('Plugin', function () {
             httpsAgents: new Https.Agent()
         };
 
+        var Reporter = Helper.getTestReporter();
         options.reporters = [{
-            reporter: GoodReporter,
+            reporter: Reporter,
             events: { wreck: '*' }
         }];
 
@@ -181,7 +183,7 @@ describe('Plugin', function () {
 
                     Wreck.get('http://127.0.0.1:' + server.connections[1].info.port + '/http', function () {
 
-                        var one = plugin.options.reporters[0].instance;
+                        var one = Reporter.instance;
                         var messages = one.messages;
 
                         expect(messages).to.have.length(2);


### PR DESCRIPTION
Fixes #357

- Enforce reporter being a constructor.
- Enforce constructor attributes a la Hapi.js (name required, version optional)
- Stash the reporter instance and metadata for other uses
  - `monitor.settings.reporters[].metadata.version`
  - `monitor.settings.reporters[].metadata.name`
  - `monitor.settings.reporters[].instance`

- Tests refactored
  - The tests were heavily dependent on Good not requiring a constructor so internal reporter methods could be mocked.
  - Had to set mocks at `GoodReporter.prototype` instead. This could be abstracted more or use something like `Sinon.sandbox` to set/clear mock methods.