### PR TITLE
Support both Wreck 5 and 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "items": "1.x.x",
     "joi": "6.x.x",
     "traverse": "0.6.6",
-    "wreck": "6.x.x"
+    "wreck": "5.x.x || 6.x.x"
   },
   "peerDependencies": {
     "hapi": ">= 8.x.x"


### PR DESCRIPTION
#367 was a breaking change for us since we lost the wreck logs because we have not updated to Wreck 6.x.x yet.

I am proposing to support both versions so as to not make it a breaking change.