### PR TITLE
updated package to support hapi 8.x.x and 9.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "good",
   "description": "Server and process monitoring plugin",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "repository": "git://github.com/hapijs/good",
   "main": "lib/index.js",
   "keywords": [
@@ -23,11 +23,11 @@
     "wreck": "6.x.x"
   },
   "peerDependencies": {
-    "hapi": ">= 8.x.x"
+    "hapi": ">=8 <10"
   },
   "devDependencies": {
     "code": "1.x.x",
-    "hapi": "8.x.x",
+    "hapi": "9.x.x",
     "lab": "5.x.x"
   },
   "scripts": {

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -402,7 +402,14 @@ describe('good', function () {
             server.register(plugin, function () {
 
                 // .stop emits the "stop" event
-                server.stop();
+                server.stop(
+                    function (err) {
+
+                        if (err) {
+                            throw err;
+                        }
+                    }
+                );
             });
         });
     });
@@ -934,7 +941,14 @@ describe('good', function () {
                             Joi.assert(event, schema);
                         }).to.not.throw();
 
-                        server.stop();
+                        server.stop(
+                            function (err) {
+
+                                if (err) {
+                                    throw err;
+                                }
+                            }
+                        );
                         done();
                     });
                 });
@@ -995,7 +1009,14 @@ describe('good', function () {
                             Joi.assert(event, schema);
                         }).to.not.throw();
 
-                        server.stop();
+                        server.stop(
+                            function (err) {
+
+                                if (err) {
+                                    throw err;
+                                }
+                            }
+                        );
                         done();
                     });
                 });
@@ -1054,7 +1075,14 @@ describe('good', function () {
 
                         expect(one.messages[0]).to.deep.equal(two.messages[0]);
                         console.error = consoleError;
-                        server.stop();
+                        server.stop(
+                            function (err) {
+
+                                if (err) {
+                                    throw err;
+                                }
+                            }
+                        );
 
                         done();
                     });


### PR DESCRIPTION
Hapi 9 requires `server.stop()` to provide a callback.