### PR TITLE
Log Error Trace

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,6 +38,9 @@ exports.GreatLog = function (event) {
     this.timestamp = event.timestamp;
     this.tags = event.tags;
     this.data = event.data;
+    if(event.data.stack) {
+      this.stack = event.data.stack;
+    }
     this.pid = process.pid;
 
     Object.freeze(this);


### PR DESCRIPTION
This is the simplest approach to log the error trace with normal logs.

Use Case is discussed in #414 