### PR TITLE
Add httpVersion to GreatResponse

### DIFF
--- a/API.md
+++ b/API.md
@@ -110,6 +110,7 @@ Event object associated with the `responseEvent` event option into Good. `reques
 - `responseTime` - calculated value of `Date.now() - request.info.received`.
 - `statusCode` - the status code of the response.
 - `pid` - the current process id.
+- `httpVersion` - the http protocol information from the request.
 - `source` - object with the following values:
     - `remoteAddress` - information about the remote address. maps to `request.info.remoteAddress`
     - `userAgent` - the user agent of the incoming request.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -132,6 +132,7 @@ exports.GreatResponse = function (request, options, filterRules) {
     this.responseTime = Date.now() - request.info.received;
     this.statusCode = res.statusCode;
     this.pid = process.pid;
+    this.httpVersion = request.raw.req.httpVersion;
     this.source = {
         remoteAddress: request.info.remoteAddress,
         userAgent: req.headers['user-agent'],

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -791,6 +791,7 @@ describe('good', function () {
                 responseTime: Joi.number().integer().required(),
                 statusCode: Joi.number().integer().required(),
                 pid: Joi.number().integer().required(),
+                httpVersion: Joi.string().required(),
                 log: Joi.array().items(Joi.object())
             });
 


### PR DESCRIPTION
This data is needed when trying to create a custom reporter for the apache combined log format.