### PR TITLE
Allow ops collecting to be disabled. Closes #411.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,63 +1,43 @@
 'use strict';
 
+// Load modules
 const Hoek = require('hoek');
+const Joi = require('joi');
 const Schema = require('./schema');
+const Monitor = require('./monitor');
 
 const internals = {
-    defaults: {
-        responseEvent: 'tail',
-        requestHeaders: false,
-        requestPayload: false,
-        responsePayload: false,
-        extensions: [],
-        reporters: [],
-        ops: {
-            interval: 15000
-        },
-        filter: {}
+    onPostStop(monitor) {
+
+        return (server, next) => {
+
+            monitor.stop(next);
+        };
+    },
+    onPreStart(monitor, options) {
+
+        return (server, next) => {
+
+            const interval = options.ops.interval;
+            monitor.startOps(interval);
+            return next();
+        };
     }
 };
 
-
-// Load modules
-const Monitor = require('./monitor');
-
-
-const onPostStop = (monitor) => {
-
-    return (server, next) => {
-
-        monitor.stop(next);
-    };
-};
-
-
-const onPreStart = (monitor, options) => {
-
-    return (server, next) => {
-
-        const interval = options.ops.interval;
-        monitor.startOps(interval);
-        return next();
-    };
-};
-
-
 exports.register = (server, options, next) => {
 
-    options = Hoek.applyToDefaultsWithShallow(internals.defaults, options, ['reporters']);
+    const result = Joi.validate(options, Schema);
+    Hoek.assert(!result.error, 'Invalid', 'monitorOptions', 'options', result.error);
 
-    // Validate settings
-    Schema.assert('monitorOptions', options);
-
-    const monitor = new Monitor(server, options);
+    const monitor = new Monitor(server, result.value);
     server.expose('monitor', monitor);
     server.ext([{
         type: 'onPostStop',
-        method: onPostStop(monitor)
+        method: internals.onPostStop(monitor)
     }, {
         type: 'onPreStart',
-        method: onPreStart(monitor, options)
+        method: internals.onPreStart(monitor, options)
     }]);
 
     return monitor.start(next);

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -42,7 +42,7 @@ class Monitor extends Events.EventEmitter {
             responsePayload: this.settings.responsePayload
         };
 
-        this._ops = new Oppsy(server, options.ops.config);
+        this._ops = this.settings.ops && new Oppsy(server, this.settings.ops.config);
 
         // Event handlers
 
@@ -93,7 +93,7 @@ class Monitor extends Events.EventEmitter {
 
     startOps(interval) {
 
-        this._ops.start(interval);
+        this._ops && this._ops.start(interval);
     }
 
     start(callback) {
@@ -157,11 +157,14 @@ class Monitor extends Events.EventEmitter {
                 this._server.on(event, handler);
             });
 
-            this._ops.on('ops', this._opsHandler);
-            this._ops.on('error', (err) => {
+            if (this._ops) {
+                this._ops.on('ops', this._opsHandler);
+                this._ops.on('error', (err) => {
 
-                console.error(err);
-            });
+                    console.error(err);
+                });
+            }
+
             Wreck.on('response', this._state.wreckHandler);
 
             // Events can not be any of ['log', 'request-error', 'ops', 'request', 'response', 'tail']
@@ -180,7 +183,8 @@ class Monitor extends Events.EventEmitter {
         const state = this._state;
 
         Wreck.removeListener('response', state.wreckHandler);
-        this._ops.stop();
+
+        this._ops && this._ops.stop();
 
         internals.iterateOverEventHash(state.handlers, (event, handler) => {
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2,25 +2,16 @@
 
 // Load Modules
 
-const Hoek = require('hoek');
 const Joi = require('joi');
 
-const internals = {};
-
-exports.assert = function (type, options) {
-
-    const error = Joi.validate(options, internals[type]).error;
-    Hoek.assert(!error, 'Invalid', type, 'options', error);
-};
-
-internals.monitorOptions = Joi.object().keys({
-    requestHeaders: Joi.boolean().default(false),
-    requestPayload: Joi.boolean().default(false),
-    responsePayload: Joi.boolean().default(false),
+module.exports = Joi.object().keys({
+    requestHeaders: Joi.bool().default(false),
+    requestPayload: Joi.bool().default(false),
+    responsePayload: Joi.bool().default(false),
     reporters: Joi.array().items(Joi.object(), Joi.string()).default([]),
     responseEvent: Joi.string().valid('response', 'tail').default('tail'),
     extensions: Joi.array().items(Joi.string().invalid('log', 'request-error', 'ops', 'request', 'response', 'tail')).default([]),
-    ops: Joi.object().optional().default({
+    ops: Joi.alternatives([Joi.object(), Joi.bool().allow(false)]).default({
         config: {},
         interval: 15000
     }),

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "code": "2.x.x",
     "hapi": "10.x.x",
     "insync": "2.1.x",
-    "lab": "7.3.x"
+    "lab": "7.3.0"
   },
   "scripts": {
     "test": "lab -m 5000 -t 100 -v -La code",


### PR DESCRIPTION
Also moved around validation logic to get more use from `Joi.default`