### PR TITLE
Improved filter option to also filter `query`

### DIFF
--- a/API.md
+++ b/API.md
@@ -50,7 +50,7 @@ set `options` to an object with the following optional settings:
         - "remove" - `delete`s the value
         - a valid regular express string. Only supports a single group. Ex: `"(\\d{4})$"` will replace the last four digits with "X"s. Take extra care when creating this string. You will need to make sure that the resultant RegExp object is what you need.
 
-    `filter` can be used to remove potentially sensitive information (credit card numbers, social security numbers, etc.) from the log payloads before they are sent out to reporters. This setting only impacts `response` events and only if payloads are included via `requestPayload` and `responsePayload`. `filter` is intended to impact the reporting of ALL downstream reporters. If you want filtering in only one, you will need to create a customized reporter. The filtering is done recursively so if you want to "censor" `ccn`, anywhere `ccn` appears in request or response bodies will be "censor"ed. Currently, you can only filter leaf nodes; nothing with children.
+    `filter` can be used to remove potentially sensitive information (credit card numbers, social security numbers, etc.) from the log payloads before they are sent out to reporters. This setting only impacts `response` events and applies to properties `query`, `requestPayload` and `responsePayload`. `filter` is intended to impact the reporting of ALL downstream reporters. If you want filtering in only one, you will need to create a customized reporter. The filtering is done recursively so if you want to "censor" `ccn`, anywhere `ccn` appears in request or response bodies will be "censor"ed. Currently, you can only filter leaf nodes; nothing with children.
 
 ## Event Types
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ server.connection({ host: 'localhost' });
 
 var options = {
     opsInterval: 1000,
+    filter:{
+        access_token: 'censor'
+    },
     reporters: [{
         reporter: require('good-console'),
         events: { log: '*', response: '*' }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -155,6 +155,7 @@ exports.GreatResponse = function (request, options, filterRules) {
 
     if (Object.keys(filterRules).length) {
 
+        applyFilter(this.query);
         applyFilter(this.requestPayload);
         applyFilter(this.responsePayload);
     }


### PR DESCRIPTION
Filter option now filters `query` also

use case: `access_token` in `query` land