### PR TITLE
Fix leaking streams because monitor’s _dataStream is never closed

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -219,6 +219,7 @@ internals.Monitor.prototype.stop = function () {
 
     this.emit('stop');
     setTimeout(function () {
+
         self._dataStream.push(null);
     }, 0);
 };

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -218,6 +218,9 @@ internals.Monitor.prototype.stop = function () {
     });
 
     this.emit('stop');
+    setTimeout(function () {
+        self._dataStream.push(null);
+    }, 0);
 };
 
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -20,6 +20,7 @@ internals.Reporter.prototype.init = function (stream, emitter, callback) {
     });
 
     stream.on('end', function () {
+
         self.streamEnded = true;
     });
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -19,11 +19,6 @@ internals.Reporter.prototype.init = function (stream, emitter, callback) {
         }
     });
 
-    stream.on('end', function () {
-
-        self.streamEnded = true;
-    });
-
     emitter.once('stop', function () {
 
         self.stopped = true;

--- a/test/helper.js
+++ b/test/helper.js
@@ -19,6 +19,10 @@ internals.Reporter.prototype.init = function (stream, emitter, callback) {
         }
     });
 
+    stream.on('end', function () {
+        self.streamEnded = true;
+    });
+
     emitter.once('stop', function () {
 
         self.stopped = true;

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -373,6 +373,7 @@ describe('good', function () {
                 expect(monitor._server.listeners('tail')).to.have.length(0);
 
                 setTimeout(function () {
+
                     expect(one.streamEnded).to.be.true();
                     expect(two.streamEnded).to.be.true();
                     done();

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -372,12 +372,37 @@ describe('good', function () {
                 expect(monitor._server.listeners('internalError')).to.have.length(0);
                 expect(monitor._server.listeners('tail')).to.have.length(0);
 
-                setTimeout(function () {
+                done();
+            });
+        });
 
-                    expect(one.streamEnded).to.be.true();
-                    expect(two.streamEnded).to.be.true();
-                    done();
-                }, 0);
+        it('should end the dataStream', function (done) {
+
+            var monitor;
+            var options = {};
+            var reporter = {
+                init: function (stream, emitter, callback) {
+
+                    stream.on('data', function () {
+                    });
+
+                    stream.on('end', function () {
+
+                        done();
+                    });
+
+                    callback();
+                }
+            };
+
+            options.reporters = [reporter];
+
+            monitor = new Monitor(new Hapi.Server(), options);
+            monitor.start(function (err) {
+
+                expect(err).to.not.exist();
+
+                monitor.stop();
             });
         });
 

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -372,7 +372,11 @@ describe('good', function () {
                 expect(monitor._server.listeners('internalError')).to.have.length(0);
                 expect(monitor._server.listeners('tail')).to.have.length(0);
 
-                done();
+                setTimeout(function () {
+                    expect(one.streamEnded).to.be.true();
+                    expect(two.streamEnded).to.be.true();
+                    done();
+                }, 0);
             });
         });
 


### PR DESCRIPTION
I discovered this by accident in my tests: When creating and stopping hapi servers (for each test) with attached `good` plugin and using `good-console` as reporter, you’ll pretty soon see something like this:
> (node) warning: possible EventEmitter memory leak detected. 11 close listeners added.

… because `good-console` pipes the monitor’s `_dataStream` (after some tranformation) into `console.stdout`, thereby attaching several event listeners to the latter. But the `_dataStream` is never closed, so the streams and event listeners remain attached to the global object.

I see two possible solutions:

1. Either change `good-console` to
    1. store a reference to the transformed stream before piping into `stdout`,
    2. listen to the monitor’s `stop` event and
    3. when it occcurs: unpipe the transformed stream.
2. or change `good` to `EOF` the `_dataStream` so that all piped-to streams are disconnected automatically.

This PR implements 2.

I’m not a big fan of the `setTimeout` workaround, but closing `_dataStream` right away causes problems when using `extensions: [stop]`: Its event handler also listens to the server’s `stop` event, receives it after the monitor and then tries to push into the closed `_dataStream`, causing an exception. (The monitor [deregisters the extension event listeners](https://github.com/hapijs/good/blob/642a98b289560465af8e46a07417b9d390e09e32/lib/monitor.js#L217), but the current `stop` event is already being processed.)

Instead of the `setTimeout` one could use a guard clause [in the extension event listener](https://github.com/hapijs/good/blob/642a98b289560465af8e46a07417b9d390e09e32/lib/monitor.js#L271) but then the `stop` event would be dropped.