### PR TITLE
Support route path in request event object

### DIFF
--- a/API.md
+++ b/API.md
@@ -145,6 +145,7 @@ Event object associated with the `responseEvent` event option into Good. `reques
     - `remoteAddress` - information about the remote address. maps to `request.info.remoteAddress`
     - `userAgent` - the user agent of the incoming request.
     - `referer` - the referer headed of the incoming request.
+- `route` - route path used by request. Maps to `request.route.path`.
 - `log` - maps to `request.getLog()` of the hapi request object.
 
 ### `Ops`

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -77,6 +77,7 @@ class RequestSent {
             userAgent: req.headers['user-agent'],
             referer: req.headers.referer
         };
+        this.route = request.route.path;
 
         this.log = request.getLog();
 

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -526,7 +526,7 @@ describe('Monitor', () => {
             ], done);
         });
 
-        it('provides additional information about "response" events using "requestHeaders","requestPayload", and "responsePayload"', { plan: 7 }, (done) => {
+        it('provides additional information about "response" events using "requestHeaders","requestPayload", and "responsePayload"', { plan: 8 }, (done) => {
 
             const server = new Hapi.Server();
             server.connection();
@@ -579,6 +579,7 @@ describe('Monitor', () => {
                             data: 'example payload'
                         });
                         expect(response.responsePayload).to.equal('done');
+                        expect(response.route).to.equal('/');
                         server.stop(callback);
                     });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -38,6 +38,12 @@ describe('utils', () => {
             },
             method: 'POST',
             path: '/',
+            route: {
+                method: 'POST',
+                path: '/',
+                realm: {},
+                settings: {}
+            },
             query: {},
             responseTime: 123,
             connection: {


### PR DESCRIPTION
I provide a pull request to extend the request event object with the root path.

With this path information, it is possible to provide a route specific event handling and interpreation. We use this information, to extend logging and monitoring informations (with good-bunyan and influx) with the hapi route.