### PR TITLE
Update link to good-loggly

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This is a list of good-reporters under the hapijs umbrella:
 ### Community powered
 Here are some additional reporters that are available from the hapijs community:
 - [good-influxdb](https://github.com/totherik/good-influxdb)
-- [good-loggly](https://github.com/fhemberger/good-loggly)
+- [good-loggly](https://github.com/continuationlabs/good-loggly)
 - [good-winston](https://github.com/lancespeelmon/good-winston)
 - [hapi-good-logstash](https://github.com/atroo/hapi-good-logstash)
 - [good-graylog2](https://github.com/CascadeEnergy/good-graylog2)


### PR DESCRIPTION
I'm no longer maintainer of `good-loggly`.