### PR TITLE
Removed wreck logging. Closes #402.

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -8,7 +8,6 @@ const Async = require('async');
 const Hoek = require('hoek');
 const Oppsy = require('oppsy');
 const Pumpify = require('pumpify');
-const Wreck = require('wreck');
 
 const Package = require('../package.json');
 const Utils = require('./utils');
@@ -70,11 +69,6 @@ class Monitor {
         this._opsHandler = (results) => {
 
             this.push(() => new Utils.Ops(results));
-        };
-
-        this._wreckHandler = (error, request, response, start, uri) => {
-
-            this.push(() => new Utils.Wreck(error, request, response, start, uri));
         };
 
         this._extensionHandler = function () {
@@ -172,8 +166,6 @@ class Monitor {
                 return callback(error);
             }
 
-            this._state.wreckHandler = this._wreckHandler;
-
             this._state.handlers.log = this._logHandler;
             this._state.handlers['request-error'] = this._errorHandler;
             this._state.handlers[this.settings.responseEvent] = this._responseHandler;
@@ -193,8 +185,6 @@ class Monitor {
                 });
             }
 
-            Wreck.on('response', this._state.wreckHandler);
-
             // Events can not be any of ['log', 'request-error', 'ops', 'request', 'response', 'tail']
             for (let i = 0; i < this.settings.extensions.length; ++i) {
                 const event = this.settings.extensions[i];
@@ -210,8 +200,6 @@ class Monitor {
     stop(callback) {
 
         const state = this._state;
-
-        Wreck.removeListener('response', state.wreckHandler);
 
         if (this._ops) {
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -141,44 +141,6 @@ class RequestLog {
 }
 
 
-// Payload for "wreck" events
-class Wreck {
-    constructor(error, request, response, start, uri) {
-
-        request = Object.assign({}, request);
-        response = Object.assign({}, response);
-        uri = Object.assign({}, uri);
-        this.event = 'wreck';
-        this.timestamp = Date.now();
-        this.timeSpent = this.timestamp - start;
-        this.pid = process.pid;
-
-        if (error) {
-            this.error = {
-                message: error.message,
-                stack: error.stack
-            };
-        }
-
-        this.request = {
-            method: uri.method,
-            path: uri.path,
-            url: uri.href,
-            protocol: uri.protocol,
-            host: uri.host,
-            headers: request._headers
-        };
-
-        this.response = {
-            statusCode: response.statusCode,
-            statusMessage: response.statusMessage,
-            headers: response.headers
-        };
-        this.config = internals.extractConfig(request);
-    }
-}
-
-
 class NoOp extends Stream.Transform {
     constructor() {
 
@@ -197,6 +159,5 @@ module.exports = {
     Ops,
     RequestLog,
     RequestSent,
-    Wreck,
     NoOp
 };

--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
     "hoek": "3.x.x",
     "joi": "7.x.x",
     "oppsy": "1.x.x",
-    "pumpify": "1.3.x",
-    "traverse": "0.6.6",
-    "wreck": "7.x.x"
+    "pumpify": "1.3.x"
   },
   "peerDependencies": {
     "hapi": ">=10.x.x"

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -3,16 +3,11 @@
 // Load modules
 
 const Http = require('http');
-const Fs = require('fs');
 
+const Async = require('async');
 const Code = require('code');
 const Hapi = require('hapi');
-const Async = require('async');
 const Lab = require('lab');
-const Wreck = require('wreck');
-
-// Done for testing because Wreck is a singleton and every test run ads one event to it
-Wreck.setMaxListeners(0);
 
 const GoodReporter = require('./fixtures/reporters');
 const Stringify = require('./fixtures/reporter');
@@ -865,69 +860,6 @@ describe('Monitor', () => {
                         payload:[]
                     });
                     callback();
-                }
-            ], done);
-        });
-
-        it('reports on outbound wreck requests', { plan: 11 }, (done) => {
-
-            const server = new Hapi.Server();
-            const tls = {
-                key: Fs.readFileSync(process.cwd() + '/test/fixtures/server.key', { encoding: 'utf8' }),
-                cert: Fs.readFileSync(process.cwd() + '/test/fixtures/server.cert', { encoding: 'utf8' })
-            };
-
-            server.connection({ port: 0, labels: ['https'], tls });
-            server.connection({ port: 0, labels: ['http'] });
-            server.route({
-                method: 'GET',
-                path: '/',
-                handler: function (request, reply) {
-
-                    reply('/');
-                }
-            });
-
-            server.select('http').route({
-                method: 'GET',
-                path: '/http',
-                handler: function (request, reply) {
-
-                    reply('http');
-                }
-            });
-
-            const out = new GoodReporter.Writer(true);
-            const monitor = internals.monitorFactory(server, { reporters: { foo: [out] } });
-
-            Async.series([
-                server.start.bind(server),
-                monitor.start.bind(monitor),
-                (callback) => {
-
-                    Wreck.get(server.connections[0].info.uri + '/', { rejectUnauthorized: false }, () => {
-
-                        Wreck.get(server.connections[1].info.uri + '/http', () => {
-
-                            expect(out.data).to.have.length(4);
-                            const one = out.data[1];
-                            const two = out.data[3];
-
-                            expect(one).to.be.an.instanceof(Utils.Wreck);
-                            expect(one.event).to.equal('wreck');
-                            expect(one.request.protocol).to.equal('https:');
-                            expect(one.request.host).to.exist();
-                            expect(one.request.path).to.equal('/');
-
-                            expect(two).to.be.an.instanceof(Utils.Wreck);
-                            expect(two.event).to.equal('wreck');
-                            expect(two.request.protocol).to.equal('http:');
-                            expect(two.request.host).to.exist();
-                            expect(two.request.path).to.equal('/http');
-
-                            server.stop(done);
-                        });
-                    });
                 }
             ], done);
         });

--- a/test/utils.js
+++ b/test/utils.js
@@ -18,34 +18,6 @@ const it = lab.it;
 
 describe('utils', () => {
 
-    describe('Wreck()', () => {
-
-        it('handles a null request and response', { plan: 2 }, (done) => {
-
-            const greatWreck = new Utils.Wreck();
-            expect(greatWreck.request).to.exist();
-            expect(greatWreck.response).to.exist();
-            done();
-        });
-
-        it('reports on errors', { plan: 1 }, (done) => {
-
-            const error = new Error('my error');
-            const greatWreck = new Utils.Wreck(error);
-
-            expect(greatWreck.error.message).to.equal('my error');
-            done();
-        });
-
-        it('contains the current pid', { plan: 1 }, (done) => {
-
-            const greatWreck = new Utils.Wreck();
-
-            expect(greatWreck.pid).to.equal(process.pid);
-            done();
-        });
-    });
-
     describe('RequestSent()', () => {
 
         const _request = {


### PR DESCRIPTION
As stated in the associated link, I'll be willing to add this back in when the eventing from `Wreck` is more predictable. In the current implementation, there are way too many variables to allow it to work properly 100% of the time.