### PR TITLE
first examples

### DIFF
--- a/examples/censoring-with-white-out.md
+++ b/examples/censoring-with-white-out.md
@@ -6,11 +6,15 @@
 console: [{
     module: 'good-squeeze',
     name: 'Squeeze',
-    args: [{ log: '*', response: '*' }]
+    args: [{
+        log: '*',
+        response: '*'
+    }]
 }, {
     module: 'white-out',
-    args: [{ password: 'remove',
-        age: `censor`
+    args: [{
+        password: 'remove',
+        age: 'censor'
     }]
 }, {
     module: 'good-console'

--- a/examples/censoring-with-white-out.md
+++ b/examples/censoring-with-white-out.md
@@ -33,4 +33,4 @@ Sanitized event data streams to `good-console` for formatting. See the `good con
 
 Formatted events stream to `process.stdout` for display.
 
-You can use `white-out` with files, http, and other output types by adding the `white-out` configuration to the stream spec.
+You can use `white-out` with files, http, and other output types by adding the `white-out` configuration to the stream spec. See [white-out](https://github.com/continuationlabs/white-out) for more details.

--- a/examples/filtering-with-white-out.md
+++ b/examples/filtering-with-white-out.md
@@ -1,0 +1,32 @@
+# Censoring Data with `white-out`
+
+## Basic Example
+
+```
+console: [{
+    module: 'good-squeeze',
+    name: 'Squeeze',
+    args: [{ log: '*', response: '*' }]
+}, {
+    module: 'white-out',
+    args: [{ password: 'remove',
+        age: `censor`
+    }]
+}, {
+    module: 'good-console'
+}, 'stdout']
+```
+
+**NOTE: This example is untested. Please submit a PR to remove this note if you test and it works or to correct if it doesn't.**
+
+This reporter spec logs response and log events to the console. It removes any data with key `password` (will not appear in output) and censors data with key `age` (appears as Xs).
+
+It uses `good-squeeze` to select only log and response events.
+
+Events that pass the filter go to `white-out` to censor or remove identified keys. Note that `white-out` will look for keys in the entire object, including nested objects.
+
+Sanitized event data streams to `good-console` for formatting. See the `good console` [constructor docs](https://github.com/hapijs/good-console#new-goodconsoleconfig) for details on `args` values.
+
+Formatted events stream to `process.stdout` for display.
+
+You can use `white-out` with files, http, and other output types by adding the `white-out` configuration to the stream spec.

--- a/examples/good-squeeze-tips.md
+++ b/examples/good-squeeze-tips.md
@@ -3,7 +3,7 @@
 - [Separators in JSON Streams](#Separators-in-JSON-streams)
 - [Tag Filtering](#Tag-Filtering)
 
-### Separators in JSON Streams
+## Separators in JSON Streams
 
 To insert a comma between JSON-formatted objects, add `args` to the SafeJson formatter. `good` passes the `args` array to the [SafeJson constructor](https://github.com/hapijs/good-squeeze#safejsonoptions-stringify).
 
@@ -25,7 +25,7 @@ file: [{
 }]
 ```
 
-### Tag Filtering
+## Tag Filtering
 
 To filter events by tags, pass `good-squeeze` a string or array of tags. See the [Squeeze constructor docs](https://github.com/hapijs/good-squeeze#squeezeevents-options) and [Squeeze.subcription docs](https://github.com/hapijs/good-squeeze#squeezesubscriptionevents) for more details.
 

--- a/examples/good-squeeze-tips.md
+++ b/examples/good-squeeze-tips.md
@@ -1,7 +1,7 @@
 # `good-squeeze` Tips
 
-- [Separators in JSON Streams](#Separators-in-JSON-streams)
-- [Tag Filtering](#Tag-Filtering)
+- [Separators in JSON Streams](#separators-in-json-streams)
+- [Tag Filtering](#tag-filtering)
 
 ## Separators in JSON Streams
 
@@ -36,7 +36,8 @@ console: [{
     args: [{
         log: ['database', 'api'],
         response: 'hapi',
-        error: '*' }]
+        error: '*'
+    }]
 }, {
     module: 'good-console'
 }, 'stdout']

--- a/examples/good-squeeze-tips.md
+++ b/examples/good-squeeze-tips.md
@@ -1,0 +1,45 @@
+# `good-squeeze` Tips
+
+- [Separators in JSON Streams](#Separators-in-JSON-streams)
+- [Tag Filtering](#Tag-Filtering)
+
+### Separators in JSON Streams
+
+To insert a comma between JSON-formatted objects, add `args` to the SafeJson formatter. `good` passes the `args` array to the [SafeJson constructor](https://github.com/hapijs/good-squeeze#safejsonoptions-stringify).
+
+```
+file: [{
+    module: 'good-squeeze',
+    name: 'Squeeze',
+    args: [{ ops: '*' }]
+}, {
+    module: 'good-squeeze',
+    name: 'SafeJson',
+    args: [
+        null,
+        { separator: ',' }
+    ]
+}, {
+    module: 'good-file',
+    args: ['./test/fixtures/awesome_log']
+}]
+```
+
+### Tag Filtering
+
+To filter events by tags, pass `good-squeeze` a string or array of tags. See the [Squeeze constructor docs](https://github.com/hapijs/good-squeeze#squeezeevents-options) and [Squeeze.subcription docs](https://github.com/hapijs/good-squeeze#squeezesubscriptionevents) for more details.
+
+```
+console: [{
+    module: 'good-squeeze',
+    name: 'Squeeze',
+    args: [{
+        log: ['database', 'api'],
+        response: 'hapi',
+        error: '*' }]
+}, {
+    module: 'good-console'
+}, 'stdout']
+```
+
+This reporter reports log events tagged `database`, `api` or both, response events tagged `hapi` and all error events.

--- a/examples/log-to-console.md
+++ b/examples/log-to-console.md
@@ -1,0 +1,21 @@
+# Log to Console
+
+## Basic Example
+
+```
+console: [{
+    module: 'good-squeeze',
+    name: 'Squeeze',
+    args: [{ log: '*', response: '*' }]
+}, {
+    module: 'good-console'
+}, 'stdout']
+```
+
+This reporter spec logs response and log events to the console.
+
+It uses `good-squeeze` to select only log and response events.
+
+Events that pass the filter stream to `good-console` for formatting. See the `good console` [constructor docs](https://github.com/hapijs/good-console#new-goodconsoleconfig) for details on `args` values.
+
+Formatted events stream to `process.stdout` for display.

--- a/examples/log-to-console.md
+++ b/examples/log-to-console.md
@@ -6,7 +6,10 @@
 console: [{
     module: 'good-squeeze',
     name: 'Squeeze',
-    args: [{ log: '*', response: '*' }]
+    args: [{
+        log: '*',
+        response: '*'
+    }]
 }, {
     module: 'good-console'
 }, 'stdout']

--- a/examples/log-to-file.md
+++ b/examples/log-to-file.md
@@ -27,7 +27,7 @@ Events that pass the filter stream to `good-squeeze` SafeJson, which transforms 
 
 Events formatted as JSON strings stream to `good-file`, which writes them to `./test/fixtures/awesome_log`.
 
-### Log Rotation
+## Log Rotation
 
 `good-file` does not do log rotation. See [rotating-file-stream](https://github.com/iccicci/rotating-file-stream) for one alternative. See the [rotating-file-stream constructor docs](https://github.com/iccicci/rotating-file-stream#new-rotatingfilestreamfilename-options) for parameter details.
 

--- a/examples/log-to-file.md
+++ b/examples/log-to-file.md
@@ -1,0 +1,72 @@
+# Log to File
+
+- [Basic Example](#basic-example)
+- [Separators in JSON Streams](#Separators-in-JSON-streams)
+- [Log Rotation](#log-rotation)
+
+## Basic Example
+
+```
+file: [{
+    module: 'good-squeeze',
+    name: 'Squeeze',
+    args: [{ ops: '*' }]
+}, {
+    module: 'good-squeeze',
+    name: 'SafeJson'
+}, {
+    module: 'good-file',
+    args: ['./test/fixtures/awesome_log']
+}]
+```
+
+This reporter spec logs ops events to a file.
+
+It uses the `good-squeeze` Squeeze function to select only ops events.
+
+Events that pass the filter stream to `good-squeeze` SafeJson for formatting.
+
+JSON-formatted events stream to `good-file`, which writes them to `./test/fixtures/awesome_log`.
+
+### Separators in JSON Streams
+
+To insert a comma between JSON-formatted objects, add `args` to the SafeJson formatter. `good` passes the `args` array to the [SafeJson constructor](https://github.com/hapijs/good-squeeze#safejsonoptions-stringify).
+
+```
+file: [{
+    module: 'good-squeeze',
+    name: 'Squeeze',
+    args: [{ ops: '*' }]
+}, {
+    module: 'good-squeeze',
+    name: 'SafeJson',
+    args: [{}, { separator: ',' }]
+}, {
+    module: 'good-file',
+    args: ['./test/fixtures/awesome_log']
+}]
+```
+
+### Log Rotation
+
+`good-file` does not do log rotation. See [rotating-file-stream](https://github.com/iccicci/rotating-file-stream) for one alternative. See the [rotating-file-stream constructor docs](https://github.com/iccicci/rotating-file-stream#new-rotatingfilestreamfilename-options) for parameter details.
+
+```
+file: [{
+    module: 'good-squeeze',
+    name: 'Squeeze',
+    args: [{ ops: '*' }]
+}, {
+    module: 'good-squeeze',
+    name: 'SafeJson',
+    args: [{}, { separator: ',' }]
+}, {
+    module: 'rotating-file-stream',
+    args: ['ops_log', {
+        size: '1000B',
+        path: './logs'
+    }]
+}]
+```
+
+This reporter outputs JSON to files in the `./logs` directory that rotate when the file size exceeds 1000 bytes (useful for testing rotation). It uses `rotating-file-stream`'s default naming which is YYYYMMDD-HHMM-nn-filename (For example: `20160509-2056-01-ops_log`, `20160509-2056-02-ops_log`.)

--- a/examples/log-to-file.md
+++ b/examples/log-to-file.md
@@ -1,7 +1,6 @@
 # Log to File
 
 - [Basic Example](#basic-example)
-- [Separators in JSON Streams](#Separators-in-JSON-streams)
 - [Log Rotation](#log-rotation)
 
 ## Basic Example
@@ -24,28 +23,9 @@ This reporter spec logs ops events to a file.
 
 It uses the `good-squeeze` Squeeze function to select only ops events.
 
-Events that pass the filter stream to `good-squeeze` SafeJson for formatting.
+Events that pass the filter stream to `good-squeeze` SafeJson, which transforms the event data into a JSON string.
 
-JSON-formatted events stream to `good-file`, which writes them to `./test/fixtures/awesome_log`.
-
-### Separators in JSON Streams
-
-To insert a comma between JSON-formatted objects, add `args` to the SafeJson formatter. `good` passes the `args` array to the [SafeJson constructor](https://github.com/hapijs/good-squeeze#safejsonoptions-stringify).
-
-```
-file: [{
-    module: 'good-squeeze',
-    name: 'Squeeze',
-    args: [{ ops: '*' }]
-}, {
-    module: 'good-squeeze',
-    name: 'SafeJson',
-    args: [{}, { separator: ',' }]
-}, {
-    module: 'good-file',
-    args: ['./test/fixtures/awesome_log']
-}]
-```
+Events formatted as JSON strings stream to `good-file`, which writes them to `./test/fixtures/awesome_log`.
 
 ### Log Rotation
 
@@ -59,7 +39,7 @@ file: [{
 }, {
     module: 'good-squeeze',
     name: 'SafeJson',
-    args: [{}, { separator: ',' }]
+    args: [ null, { separator: ',' }]
 }, {
     module: 'rotating-file-stream',
     args: ['ops_log', {

--- a/examples/log-to-file.md
+++ b/examples/log-to-file.md
@@ -39,13 +39,19 @@ file: [{
 }, {
     module: 'good-squeeze',
     name: 'SafeJson',
-    args: [ null, { separator: ',' }]
+    args: [
+        null,
+        { separator: ',' }
+    ]
 }, {
     module: 'rotating-file-stream',
-    args: ['ops_log', {
-        size: '1000B',
-        path: './logs'
-    }]
+    args: [
+        'ops_log',
+        {
+            size: '1000B',
+            path: './logs'
+        }
+    ]
 }]
 ```
 

--- a/examples/log-to-http.md
+++ b/examples/log-to-http.md
@@ -1,0 +1,26 @@
+# Log to HTTP
+
+## Basic Example
+
+```
+http: [{
+    module: 'good-squeeze',
+    name: 'Squeeze',
+    args: [{ error: '*' }]
+}, {
+    module: 'good-http',
+    args: ['http://prod.logs:3000', {
+        wreck: {
+            headers: { 'x-api-key': 12345 }
+        }
+    }]
+}
+```
+
+### Discussion
+
+This reporter spec logs error events to the console.
+
+It uses the `good-squeeze` Squeeze function to select only error events.
+
+Events that pass the filter stream through `good-http` to the endpoint URL specified in the `args` array. See the `good-http` [constructor docs](https://github.com/hapijs/good-http#goodhttp-endpoint-config) for other arguments and payload details.

--- a/examples/log-to-http.md
+++ b/examples/log-to-http.md
@@ -9,11 +9,14 @@ http: [{
     args: [{ error: '*' }]
 }, {
     module: 'good-http',
-    args: ['http://prod.logs:3000', {
-        wreck: {
-            headers: { 'x-api-key': 12345 }
+    args: [
+        'http://prod.logs:3000',
+        {
+            wreck: {
+                headers: { 'x-api-key': 12345 }
+            }
         }
-    }]
+    ]
 }
 ```
 


### PR DESCRIPTION
Adds `examples` directory and examples for console, file, and http logging based on docs. Includes example of passing parameters to SafeJson (tested, works), log rotation (tested, works), and using white-out to censor data (untested).