### PR TITLE
Restored wreck logging. Closes #469.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ config.json
 coverage.*
 lib-cov
 complexity.md
+.vscode/**

--- a/API.md
+++ b/API.md
@@ -29,6 +29,7 @@ as general events are a process-wide facility and will result in duplicated log 
     - 'response' - the response was sent but request tails may still be pending.
     - 'tail' - the response was sent and all request tails completed.
 - `[extensions]` - an array of [hapi event names](https://github.com/hapijs/hapi/blob/master/API.md#server-events) to listen for and report via the good reporting mechanism. Can not be any of ['log', 'request-error', 'ops', 'request', 'response', 'tail']. **Disclaimer** This option should be used with caution. This option will allow users to listen to internal events that are not meant for public consumption. The list of available events can change with any changes to the hapi event system. Also, *none* of the official hapijs reporters have been tested against these custom events. The schema for these events can not be guaranteed because they vary from version to version of hapi.
+- `[wreck]` - a boolean controlling wreck response logging. Defaults to `false`. 
 - `[reporters]` - Defaults to `{}`. `reporters` is a `key`, `value` pair where the `key` is a reporter name and the `value` is an array of mixed value types. Valid values for the array items are:
     - streams specifications object with the following keys
         - `module` - can be :
@@ -173,7 +174,7 @@ The `toJSON` method of `GreatError` has been overwritten because `Error` objects
 
 ### `RequestSent`
 
-Event object associated with the `responseEvent` event option into Good. `request`
+Event object associated with the `responseEvent` event option into Good.
 
 - `event` - 'response'
 - `timestamp` - JavaScript timestamp that maps to `request.info.received`.
@@ -196,6 +197,9 @@ Event object associated with the `responseEvent` event option into Good. `reques
 - `log` - maps to `request.getLog()` of the hapi request object.
 - `tags` - array of strings representing any tags from route config. Maps to `request.route.settings.tags`.
 - `config` - plugin-specific config object combining `request.route.settings.plugins.good` and `request.plugins.good`. Request-level overrides route-level. Reporters could use `config` for additional filtering logic.
+- `headers` - the request headers if `includes.request` includes "headers"
+- `requestPayload` - the request payload if `includes.request` includes "payload"
+- `responsePayload` - the response payload if `includes.response` includes "payload"
 
 ### `Ops`
 
@@ -239,6 +243,29 @@ Event object associated with the "request" event. This is the hapi event emitter
 - `method` - method used by the request. Maps to `request.method`.
 - `path` - incoming path requested. Maps to `request.path`.
 - `config` - plugin-specific config object combining `request.route.settings.plugins.good` and `request.plugins.good`. Request-level overrides route-level. Reporters could use `config` for additional filtering logic.
+
+### `WreckResponse`
+
+Event object emitted whenever Wreck finishes making a request to a remote server.
+
+- `event` - 'wreck'
+- `timestamp` - timestamp of the incoming `event` object
+- `timeSpent` - how many ms it took to make the request
+- `pid` - the current process id
+- `request` - information about the outgoing request
+    - `method` - `GET`, `POST`, etc
+    - `path` - the path requested
+    - `url` - the full URL to the remote resource
+    - `protocol` - e.g. `http:`
+    - `host` - the remote server host
+    - `headers` - object containing all outgoing request headers
+- `response` - information about the incoming request
+    - `statusCode` - the http status code of the response e.g. 200
+    - `statusMessage` - e.g. `OK`
+    - `headers` - object containing all incoming response headers
+- `error` - if the response errored, this field will be populated
+    - `message` - the error message
+    - `stack` - the stack trace of the error
 
 ### Extension Payloads
 

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -23,11 +23,9 @@ class Monitor {
     constructor(server, options) {
 
         this.settings = options;
-        this._state = {
-            handlers: {},
-            extensions: {}
-        };
+        this._state = { report: false };
         this._server = server;
+        this._reporters = {};
 
         const reducer = (obj, value) => {
 
@@ -37,8 +35,6 @@ class Monitor {
 
         const reqOptions = this.settings.includes.request.reduce(reducer, {});
         const resOptions = this.settings.includes.response.reduce(reducer, {});
-
-        this._reporters = {};
 
         this._ops = this.settings.ops && new Oppsy(server, this.settings.ops.config);
 
@@ -69,19 +65,13 @@ class Monitor {
             this.push(() => new Utils.Ops(results));
         };
 
-        this._extensionHandler = function () {
+        if (this.settings.wreck) {
+            this._wreckHandler = (error, request, response, start, uri) => {
 
-            const args = Array(arguments.length);
-            for (let i = 0; i < arguments.length; ++i) {
-                args[i] = arguments[i];
-            }
-            const event = {
-                event: args.shift(),
-                timestamp: Date.now(),
-                payload: args
+                this.push(() => new Utils.WreckResponse(error, request, response, start, uri));
             };
-            this.push(() => Object.assign({}, event));
-        };
+        }
+
     }
 
     startOps(interval) {
@@ -91,7 +81,7 @@ class Monitor {
 
     start(callback) {
 
-        internals.forOwn(this.settings.reporters, (reporterName, streamsSpec) => {
+        internals.forOwn(this.settings.reporters, (streamsSpec, reporterName) => {
 
             if (!streamsSpec.length) {
                 return;
@@ -140,32 +130,39 @@ class Monitor {
             });
         });
 
-        this._state.handlers.log = this._logHandler;
-        this._state.handlers['request-error'] = this._errorHandler;
-        this._state.handlers[this.settings.responseEvent] = this._responseHandler;
-        this._state.handlers.request = this._requestLogHandler;
+        this._state.report = true;
 
         // Initialize Events
-        internals.forOwn(this._state.handlers, (event, handler) => {
+        this._server.on('log', this._logHandler);
+        this._server.on('request-error', this._errorHandler);
+        this._server.on(this.settings.responseEvent, this._responseHandler);
+        this._server.on('request', this._requestLogHandler);
 
-            this._server.on(event, handler);
-        });
+        if (this.settings.wreck) {
+            const wreck = Symbol.for('wreck');
+            process[wreck].on('response', this._wreckHandler);
+        }
 
         if (this._ops) {
             this._ops.on('ops', this._opsHandler);
-            this._ops.on('error', (err) => {
-
-                console.error(err);
-            });
+            this._ops.on('error', console.error);
         }
 
+        const self = this;
         // Events can not be any of ['log', 'request-error', 'ops', 'request', 'response', 'tail']
         for (let i = 0; i < this.settings.extensions.length; ++i) {
             const event = this.settings.extensions[i];
-            const handler = this._extensionHandler.bind(this, event);
+            // Can't use () => because of "arguments"
+            this._server.on(this.settings.extensions[i], function () {
 
-            this._state.extensions[event] = handler;
-            this._server.on(this.settings.extensions[i], handler);
+                const args = Array.from(arguments);
+                const payload = {
+                    event,
+                    timestamp: Date.now(),
+                    payload: args
+                };
+                self.push(() => Object.assign({}, payload));
+            });
         }
 
         return callback();
@@ -173,6 +170,7 @@ class Monitor {
     stop(callback) {
 
         const state = this._state;
+        state.report = false;
 
         if (this._ops) {
 
@@ -180,17 +178,7 @@ class Monitor {
             this._ops.removeAllListeners();
         }
 
-        internals.forOwn(state.handlers, (event, handler) => {
-
-            this._server.removeListener(event, handler);
-        });
-
-        internals.forOwn(state.extensions, (event, handler) => {
-
-            this._server.removeListener(event, handler);
-        });
-
-        internals.forOwn(this._reporters, (name, reporter) => {
+        internals.forOwn(this._reporters, (reporter) => {
 
             reporter.end();
         });
@@ -201,10 +189,12 @@ class Monitor {
     }
     push(value) {
 
-        internals.forOwn(this._reporters, (name, reporter) => {
+        if (this._state.report) {
+            internals.forOwn(this._reporters, (reporter) => {
 
-            reporter.write(value());
-        });
+                reporter.write(value());
+            });
+        }
     }
 }
 
@@ -215,6 +205,6 @@ internals.forOwn = (obj, func) => {
     const keys = Object.keys(obj);
     for (let i = 0; i < keys.length; ++i) {
         const key = keys[i];
-        func(key, obj[key]);
+        func(obj[key], key);
     }
 };

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -29,5 +29,6 @@ exports.monitor = Joi.object().keys({
     ops: Joi.alternatives([Joi.object(), Joi.bool().allow(false)]).default({
         config: {},
         interval: 15000
-    })
+    }),
+    wreck: Joi.bool().default(false)
 }).unknown(false);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -146,6 +146,40 @@ class RequestLog {
     }
 }
 
+class WreckResponse {
+    constructor(error, request, response, start, uri) {
+
+        response = response || {};
+        uri = uri || {};
+        this.event = 'wreck';
+        this.timestamp = Date.now();
+        this.timeSpent = this.timestamp - start;
+        this.pid = process.pid;
+
+        if (error) {
+            this.error = {
+                message: error.message,
+                stack: error.stack
+            };
+        }
+
+        this.request = {
+            method: uri.method,
+            path: uri.path,
+            url: uri.href,
+            protocol: uri.protocol,
+            host: uri.host,
+            headers: request._headers
+        };
+
+        this.response = {
+            statusCode: response.statusCode,
+            statusMessage: response.statusMessage,
+            headers: response.headers
+        };
+    }
+}
+
 
 class NoOp extends Stream.Transform {
     constructor() {
@@ -165,5 +199,6 @@ module.exports = {
     Ops,
     RequestLog,
     RequestSent,
-    NoOp
+    NoOp,
+    WreckResponse
 };

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "async": "2.1.x",
     "code": "4.x.x",
     "hapi": "16.x.x",
-    "lab": "11.x.x"
+    "lab": "11.x.x",
+    "wreck": "10.x.x"
   },
   "scripts": {
-    "test": "lab -m 5000 -t 100 -v -La code",
-    "test-cov-html": "lab -m 5000 -r html -o coverage.html -La code"
+    "test": "lab -m 5000 -t 100 -v -La code"
   },
   "license": "BSD-3-Clause"
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -117,4 +117,34 @@ describe('utils', () => {
             done();
         });
     });
+
+    describe('WreckResponse()', () => {
+
+        const keysUndefined = (obj) => {
+
+            const keys = Object.keys(obj);
+            for (let i = 0; i < keys.length; ++i) {
+                const key = keys[i];
+                expect(obj[key]).to.be.undefined();
+            }
+        };
+
+        it('creates a default response and uri values in case they are missing', (done) => {
+
+            const wreckValue = new Utils.WreckResponse(null, {}, null, Date.now());
+            keysUndefined(wreckValue.request);
+            keysUndefined(wreckValue.response);
+            expect(wreckValue.event).to.equal('wreck');
+            expect(wreckValue.timeSpent).to.be.a.number();
+            done();
+        });
+
+        it('attaches an error object in the event of a wreck error', (done) => {
+
+            const wreckValue = new Utils.WreckResponse(new Error('test error'), {}, null, Date.now());
+            expect(wreckValue.error.stack).to.be.a.string();
+            expect(wreckValue.error.message).to.equal('test error');
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Cleaned up event handling logic and just added a boolean to control whether events are reported on not. It was much easier and required far less code to keep a handler to all the added event listeners.
