### PR TITLE
responseTime to use request responded. Closes #530

### DIFF
--- a/API.md
+++ b/API.md
@@ -181,8 +181,7 @@ Event object associated with the response event option into Good.
 - `method` - method used by the request. Maps to `request.method`.
 - `path` - incoming path requested. Maps to `request.path`.
 - `query` - query object used by request. Maps to `request.query`.
-- `responseTime` - calculated value of `Date.now() - request.info.received`.
-- `responseSentTime` - calculated value of `request.info.responded - request.info.received`.
+- `responseTime` - calculated value of `request.info.responded - request.info.received`.
 - `statusCode` - the status code of the response.
 - `pid` - the current process id.
 - `httpVersion` - the http protocol information from the request.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -69,8 +69,7 @@ class RequestSent {
         this.method = request.method;
         this.path = request.path;
         this.query = request.query;
-        this.responseTime = Date.now() - request.info.received;
-        this.responseSentTime = request.info.responded - request.info.received;
+        this.responseTime = request.info.responded - request.info.received;
         this.statusCode = res.statusCode;
         this.pid = process.pid;
         this.httpVersion = request.raw.req.httpVersion;


### PR DESCRIPTION
Hapi 15 docs:

`responded - request response timestamp (0 is not responded yet).` 

This will use the diff of responded to received as the response event `responseTime`. Fallback to `Date.now()` behavior when responded=0 or just in case any old Hapi versions don't set this.

No test added b/c I didn't see any similar testing of event flags. Glad to add one if needed.
