### PR TITLE
Don't create a reporter if no streams were provided. Addresses #534

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -93,6 +93,10 @@ class Monitor {
 
         internals.forOwn(this.settings.reporters, (reporterName, streamsSpec) => {
 
+            if (!streamsSpec.length) {
+                return;
+            }
+
             const streamObjs = [];
             for (let i = 0; i < streamsSpec.length; ++i) {
                 const spec = streamsSpec[i];

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -245,6 +245,24 @@ describe('Monitor', () => {
 
             done();
         });
+
+        it('does not create a reporter if it has no streams', { plan: 2 }, (done) => {
+
+            const monitor = internals.monitorFactory(new Hapi.Server(), {
+                reporters: {
+                    foo: []
+                }
+            });
+
+            monitor.start((error) => {
+
+                expect(error).to.not.exist();
+
+                expect(monitor._reporters).to.have.length(0);
+
+                done();
+            });
+        });
     });
 
     describe('push()', () => {

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -246,11 +246,12 @@ describe('Monitor', () => {
             done();
         });
 
-        it('does not create a reporter if it has no streams', { plan: 2 }, (done) => {
+        it('does not create a reporter if the reporter has no streams', { plan: 3 }, (done) => {
 
             const monitor = internals.monitorFactory(new Hapi.Server(), {
                 reporters: {
-                    foo: []
+                    foo: [],
+                    bar: [new GoodReporter.Incrementer(1)]
                 }
             });
 
@@ -258,7 +259,8 @@ describe('Monitor', () => {
 
                 expect(error).to.not.exist();
 
-                expect(monitor._reporters).to.have.length(0);
+                expect(monitor._reporters).to.have.length(1);
+                expect(monitor._reporters.bar).to.exist();
 
                 done();
             });


### PR DESCRIPTION
Decided the simplest solution was just to _not create_ the reporter if no stream is provided.

See #534 