### PR TITLE
Add auth as a valid value for request in includes option

### DIFF
--- a/API.md
+++ b/API.md
@@ -20,7 +20,7 @@ as general events are a process-wide facility and will result in duplicated log 
 
 ## Options
 - `[includes]` - optional configuration object
-    - `[request]` - array of extra hapi request object fields to supply to reporters on "request" events. Valid values ['headers', 'payload']. Defaults to `[]`.
+    - `[request]` - array of extra hapi request object fields to supply to reporters on "request" events. Valid values ['headers', 'payload', 'auth']. Defaults to `[]`.
     - `[response]` - array of extra hapi response object fields to supply to reporters on "response" events. Valid values ['payload']. Defaults to `[]`.
 - `[ops]` - options for controlling the ops reporting from good. Set to `false` to disable ops monitoring completely.
     - `config` - options passed directly into the [`Oppsy`](https://github.com/hapijs/oppsy) constructor as the `config` value. Defaults to `{}`
@@ -29,7 +29,7 @@ as general events are a process-wide facility and will result in duplicated log 
     - 'response' - the response was sent but request tails may still be pending.
     - 'tail' - the response was sent and all request tails completed.
 - `[extensions]` - an array of [hapi event names](https://github.com/hapijs/hapi/blob/master/API.md#server-events) to listen for and report via the good reporting mechanism. Can not be any of ['log', 'request-error', 'ops', 'request', 'response', 'tail']. **Disclaimer** This option should be used with caution. This option will allow users to listen to internal events that are not meant for public consumption. The list of available events can change with any changes to the hapi event system. Also, *none* of the official hapijs reporters have been tested against these custom events. The schema for these events can not be guaranteed because they vary from version to version of hapi.
-- `[wreck]` - a boolean controlling wreck response logging. Defaults to `false`. 
+- `[wreck]` - a boolean controlling wreck response logging. Defaults to `false`.
 - `[reporters]` - Defaults to `{}`. `reporters` is a `key`, `value` pair where the `key` is a reporter name and the `value` is an array of mixed value types. Valid values for the array items are:
     - streams specifications object with the following keys
         - `module` - can be :
@@ -200,6 +200,7 @@ Event object associated with the `responseEvent` event option into Good.
 - `headers` - the request headers if `includes.request` includes "headers"
 - `requestPayload` - the request payload if `includes.request` includes "payload"
 - `responsePayload` - the response payload if `includes.response` includes "payload"
+- `auth` - the request auth if `includes.request` includes "auth"
 
 ### `Ops`
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -6,7 +6,7 @@ const Joi = require('joi');
 
 exports.monitor = Joi.object().keys({
     includes: Joi.object().keys({
-        request: Joi.array().items(Joi.string().valid('headers', 'payload')).default([]),
+        request: Joi.array().items(Joi.string().valid('headers', 'payload', 'auth')).default([]),
         response: Joi.array().items(Joi.string().valid('payload')).default([])
     }).default({
         request: [],

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -94,6 +94,10 @@ class RequestSent {
             this.requestPayload = request.payload;
         }
 
+        if (reqOptions.auth) {
+            this.auth = request.auth;
+        }
+
         if (resOptions.payload && request.response) {
             this.responsePayload = request.response.source;
         }

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -519,7 +519,7 @@ describe('Monitor', () => {
             ], done);
         });
 
-        it('provides additional information about "response" events using "requestHeaders","requestPayload", "responsePayload", and "requestAuth"', { plan: 9 }, (done) => {
+        it('provides additional information about "response" events using "requestHeaders","requestPayload", "responsePayload", and "requestAuth"', { plan: 10 }, (done) => {
 
             const server = new Hapi.Server();
             server.connection();

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -519,7 +519,7 @@ describe('Monitor', () => {
             ], done);
         });
 
-        it('provides additional information about "response" events using "requestHeaders","requestPayload", and "responsePayload"', { plan: 9 }, (done) => {
+        it('provides additional information about "response" events using "requestHeaders","requestPayload", "responsePayload", and "requestAuth"', { plan: 9 }, (done) => {
 
             const server = new Hapi.Server();
             server.connection();
@@ -539,7 +539,7 @@ describe('Monitor', () => {
                     foo: [out]
                 },
                 includes: {
-                    request: ['headers', 'payload'],
+                    request: ['headers', 'payload', 'auth'],
                     response: ['payload']
                 }
             });
@@ -574,6 +574,7 @@ describe('Monitor', () => {
                                 data: 'example payload'
                             });
                             expect(response.responsePayload).to.equal('done');
+                            expect(response.auth).to.exist();
                             expect(response.route).to.equal('/');
                             server.stop(callback);
                         }, 50);

--- a/test/utils.js
+++ b/test/utils.js
@@ -64,7 +64,8 @@ describe('utils', () => {
 
             const reqOpts = {
                 headers: true,
-                payload: true
+                payload: true,
+                auth: true
             };
 
             const resOpts = {


### PR DESCRIPTION
See #556.

The includes option for requests currently has valid values of ['headers', 'payload'].

It would be helpful if it could also take 'auth' as a value since it could allow logs to include user account(s) attached to the request.