### PR TITLE
Add extension function for request includes

### DIFF
--- a/API.md
+++ b/API.md
@@ -20,7 +20,20 @@ as general events are a process-wide facility and will result in duplicated log 
 
 ## Options
 - `[includes]` - optional configuration object
-    - `[request]` - array of extra hapi request object fields to supply to reporters on "request", "response", and "error" events. Valid values ['headers', 'payload']. Defaults to `[]`.
+    - `[request]` - array of extra hapi request object fields to supply to reporters on "request", "response", and "error" events. Valid values ['headers', 'payload']. Defaults to `[]`.  In addition to request object fields, a function may be provided - the result of this function will populate the extensionData field on the object supplied to reporters. Example:
+
+            request: [
+                'headers',
+                'payload', 
+                (request) => {
+                    const user = (request.auth && request.auth.credentials && request.auth.isAuthenticated) ?
+                        request.auth.credentials.username : 'anonymous';
+                    return {
+                        username: user,
+                    }; 
+                }
+            ]
+
     - `[response]` - array of extra hapi response object fields to supply to reporters on "response" events. Valid values ['payload']. Defaults to `[]`.
 - `[ops]` - options for controlling the ops reporting from good. Set to `false` to disable ops monitoring completely.
     - `config` - options passed directly into the [`Oppsy`](https://github.com/hapijs/oppsy) constructor as the `config` value. Defaults to `{}`

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -29,7 +29,12 @@ class Monitor {
 
         const reducer = (obj, value) => {
 
-            obj[value] = true;
+            if (typeof value === 'function') {
+                obj.extension = value;
+            }
+            else {
+                obj[value] = true;
+            }
             return obj;
         };
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -6,7 +6,10 @@ const Joi = require('joi');
 
 exports.monitor = Joi.object().keys({
     includes: Joi.object().keys({
-        request: Joi.array().items(Joi.string().valid('headers', 'payload')).default([]),
+        request: Joi.array().items(Joi.alternatives().try(
+            Joi.string().valid('headers', 'payload'),
+            Joi.func().arity(1)
+        )).default([]),
         response: Joi.array().items(Joi.string().valid('payload')).default([])
     }).default({
         request: [],

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,6 +43,10 @@ class RequestError {
         if (reqOptions.headers) {
             this.headers = Hoek.reach(request, 'raw.req.headers');
         }
+
+        if (reqOptions.extension) {
+            this.extensionData = reqOptions.extension(request);
+        }
     }
     toJSON() {
 
@@ -98,6 +102,10 @@ class RequestSent {
             this.requestPayload = request.payload;
         }
 
+        if (reqOptions.extension) {
+            this.extensionData = reqOptions.extension(request);
+        }
+
         if (resOptions.payload && request.response) {
             this.responsePayload = request.response.source;
         }
@@ -150,6 +158,10 @@ class RequestLog {
 
         if (reqOptions.headers) {
             this.headers = Hoek.reach(request, 'raw.req.headers');
+        }
+
+        if (reqOptions.extension) {
+            this.extensionData = reqOptions.extension(request);
         }
     }
 }


### PR DESCRIPTION
The change is to allow users to extract extra data out of the Hapi request object and populate it into an 'extensionData' field on the event passed to reporters.  My use case is for passing authentication information from request.auth (as per the example added to API.md), but it could be used for other edge cases people may have that are not worth specifically implementing in the core library.