### PR TITLE
Preserve the current zone if there is one, on e.g. request.log

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,6 +23,7 @@ class ServerLog {
         this.tags = event.tags;
         this.data = event.data;
         this.pid = process.pid;
+        this.zone = typeof Zone !== 'undefined' ? Zone.current : null;
     }
 }
 
@@ -147,6 +148,7 @@ class RequestLog {
         this.method = request.method;
         this.path = request.path;
         this.config = internals.extractConfig(request);
+        this.zone = typeof Zone !== 'undefined' ? Zone.current : null;
 
         if (reqOptions.headers) {
             this.headers = Hoek.reach(request, 'raw.req.headers');


### PR DESCRIPTION
When using zone.js all reporters are invoked in the root zone (https://github.com/hapijs/good/blob/master/lib/monitor.js#L218) because this is the current zone when registering the async event listener (https://github.com/hapijs/good/blob/master/lib/monitor.js#L147).

This patch stores the current zone (if available) in the event data which is passed to the registered reporter. The reporter is then able to run correlated tasks inside of this zone.