### PR TITLE
Migrate to hapi 17, node 8 and async/await closes #568

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,13 @@
 language: node_js
 
 node_js:
-    - "4"
-    - "6"
     - "8"
     - "node"
 
 sudo: false
 
 env:
-    - HAPI_VERSION="10"
-    - HAPI_VERSION="11"
-    - HAPI_VERSION="12"
-    - HAPI_VERSION="13"
-    - HAPI_VERSION="14"
-    - HAPI_VERSION="15"
-    - HAPI_VERSION="16"
+    - HAPI_VERSION="17"
 
 install:
     - npm install -g json

--- a/API.md
+++ b/API.md
@@ -25,11 +25,7 @@ as general events are a process-wide facility and will result in duplicated log 
 - `[ops]` - options for controlling the ops reporting from good. Set to `false` to disable ops monitoring completely.
     - `config` - options passed directly into the [`Oppsy`](https://github.com/hapijs/oppsy) constructor as the `config` value. Defaults to `{}`
     - `interval` - interval used when calling `Oppsy.start()`. Defaults to `15000`.
-- `[responseEvent]` - the event type used to capture completed requests. Defaults to 'tail'. Options are:
-    - 'response' - the response was sent but request tails may still be pending.
-    - 'tail' - the response was sent and all request tails completed.
-- `[extensions]` - an array of [hapi event names](https://github.com/hapijs/hapi/blob/master/API.md#server-events) to listen for and report via the good reporting mechanism. Can not be any of ['log', 'request-error', 'ops', 'request', 'response', 'tail']. **Disclaimer** This option should be used with caution. This option will allow users to listen to internal events that are not meant for public consumption. The list of available events can change with any changes to the hapi event system. Also, *none* of the official hapijs reporters have been tested against these custom events. The schema for these events can not be guaranteed because they vary from version to version of hapi.
-- `[wreck]` - a boolean controlling wreck response logging. Defaults to `false`. 
+- `[extensions]` - an array of [hapi event names](https://github.com/hapijs/hapi/blob/master/API.md#server-events) to listen for and report via the good reporting mechanism. Can not be any of ['log', 'ops', 'request', 'response', 'tail']. **Disclaimer** This option should be used with caution. This option will allow users to listen to internal events that are not meant for public consumption. The list of available events can change with any changes to the hapi event system. Also, *none* of the official hapijs reporters have been tested against these custom events. The schema for these events can not be guaranteed because they vary from version to version of hapi.
 - `[reporters]` - Defaults to `{}`. `reporters` is a `key`, `value` pair where the `key` is a reporter name and the `value` is an array of mixed value types. Valid values for the array items are:
     - streams specifications object with the following keys
         - `module` - can be :
@@ -136,7 +132,7 @@ At this point, data will start flowing to each of the reporters through the pipe
 - `ops` - System and process performance - CPU, memory, disk, and other metrics.
 - `response` - Information about incoming requests and the response. This maps to either the "response" or "tail" event emitted from hapi servers.
 - `log` - logging information not bound to a specific request such as system errors, background processing, configuration errors, etc. Maps to the "log" event emitted from hapi servers.
-- `error` - request responses that have a status code of 500. This maps to the "request-error" hapi event.
+- `error` - request responses that have a status code of 500. This maps to the "request" hapi event on the "error" channel.
 - `request` - Request logging information. This maps to the hapi 'request' event that is emitted via `request.log()`.
 
 ## Event Payloads
@@ -175,17 +171,17 @@ The `toJSON` method of `GreatError` has been overwritten because `Error` objects
 
 ### `RequestSent`
 
-Event object associated with the `responseEvent` event option into Good.
+Event object associated with the response event option into Good.
 
 - `event` - 'response'
 - `timestamp` - JavaScript timestamp that maps to `request.info.received`.
 - `id` - id of the request, maps to `request.id`.
-- `instance` - maps to `request.connection.info.uri`.
-- `labels` - maps to `request.connection.settings.labels`
+- `instance` - maps to `server.info.uri`.
+- `labels` - maps to `server.settings.labels`
 - `method` - method used by the request. Maps to `request.method`.
 - `path` - incoming path requested. Maps to `request.path`.
 - `query` - query object used by request. Maps to `request.query`.
-- `responseTime` - calculated value of `Date.now() - request.info.received`. Includes tail time when `responseEvent='tail'`.
+- `responseTime` - calculated value of `Date.now() - request.info.received`.
 - `responseSentTime` - calculated value of `request.info.responded - request.info.received`.
 - `statusCode` - the status code of the response.
 - `pid` - the current process id.
@@ -195,7 +191,7 @@ Event object associated with the `responseEvent` event option into Good.
     - `userAgent` - the user agent of the incoming request.
     - `referer` - the referer headed of the incoming request.
 - `route` - route path used by request. Maps to `request.route.path`.
-- `log` - maps to `request.getLog()` of the hapi request object.
+- `log` - maps to `request.logs` of the hapi request object.
 - `tags` - array of strings representing any tags from route config. Maps to `request.route.settings.tags`.
 - `config` - plugin-specific config object combining `request.route.settings.plugins.good` and `request.plugins.good`. Request-level overrides route-level. Reporters could use `config` for additional filtering logic.
 - `headers` - the request headers if `includes.request` includes "headers"
@@ -245,29 +241,6 @@ Event object associated with the "request" event. This is the hapi event emitter
 - `path` - incoming path requested. Maps to `request.path`.
 - `config` - plugin-specific config object combining `request.route.settings.plugins.good` and `request.plugins.good`. Request-level overrides route-level. Reporters could use `config` for additional filtering logic.
 - `headers` - the request headers if `includes.request` includes "headers"
-
-### `WreckResponse`
-
-Event object emitted whenever Wreck finishes making a request to a remote server.
-
-- `event` - 'wreck'
-- `timestamp` - timestamp of the incoming `event` object
-- `timeSpent` - how many ms it took to make the request
-- `pid` - the current process id
-- `request` - information about the outgoing request
-    - `method` - `GET`, `POST`, etc
-    - `path` - the path requested
-    - `url` - the full URL to the remote resource
-    - `protocol` - e.g. `http:`
-    - `host` - the remote server host
-    - `headers` - object containing all outgoing request headers
-- `response` - information about the incoming request
-    - `statusCode` - the http status code of the response e.g. 200
-    - `statusMessage` - e.g. `OK`
-    - `headers` - object containing all incoming response headers
-- `error` - if the response errored, this field will be populated
-    - `message` - the error message
-    - `stack` - the stack trace of the error
 
 ### Extension Payloads
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 Lead Maintainer: [Adam Bretz](https://github.com/arb)
 
+*good 8 only supports hapi 17+ for hapi 16 please use good 7*
 
 **good** is a hapi plugin to monitor and report on a variety of hapi server events as well as ops information from the host machine. It listens for events emitted by hapi server instances and pushes standardized events to a collection of streams.
 
@@ -14,7 +15,6 @@ Lead Maintainer: [Adam Bretz](https://github.com/arb)
 ```javascript
 const Hapi = require('hapi');
 const server = new Hapi.Server();
-server.connection();
 
 const options = {
     ops: {
@@ -54,19 +54,14 @@ const options = {
     }
 };
 
-server.register({
-    register: require('good'),
+await server.register({
+    plugin: require('good'),
     options,
-}, (err) => {
-
-    if (err) {
-        return console.error(err);
-    }
-    server.start(() => {
-        console.info(`Server started at ${ server.info.uri }`);
-    });
-
 });
+
+await server.start();
+
+console.info(`Server started at ${ server.info.uri }`);
 
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,23 +9,22 @@ const Monitor = require('./monitor');
 const internals = {
     onPostStop(monitor) {
 
-        return (server, next) => {
+        return (server, h) => {
 
-            monitor.stop(next);
+            return monitor.stop();
         };
     },
     onPreStart(monitor, options) {
 
-        return (server, next) => {
+        return (server, h) => {
 
             const interval = options.ops.interval;
             monitor.startOps(interval);
-            return next();
         };
     }
 };
 
-exports.register = (server, options, next) => {
+exports.register = (server, options) => {
 
     const result = Joi.validate(options, Schema.monitor);
     Hoek.assert(!result.error, 'Invalid', 'monitorOptions', 'options', result.error);
@@ -39,11 +38,8 @@ exports.register = (server, options, next) => {
         method: internals.onPreStart(monitor, result.value)
     }]);
 
-    return monitor.start(next);
+    monitor.start();
 };
 
 
-exports.register.attributes = {
-
-    pkg: require('../package.json')
-};
+exports.pkg = require('../package.json');

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -57,41 +57,13 @@ class Monitor {
 
         this._responseHandler = (request) => {
 
-            this.push(() => new Utils.RequestSent(reqOptions, resOptions, request));
+            this.push(() => new Utils.RequestSent(reqOptions, resOptions, request, this._server));
         };
 
         this._opsHandler = (results) => {
 
             this.push(() => new Utils.Ops(results));
         };
-
-        if (this.settings.wreck) {
-            this._wreckHandler = function (error) {
-
-                const args = Array.from(arguments).slice(1);
-                let request;
-                let response;
-                let start;
-                let uri;
-
-                // Wreck 11+ emits response event with signature (err, {req, res, start, uri})
-                const isWreckVersion11OrHigher = (args.length === 1);
-                if (isWreckVersion11OrHigher) {
-                    request = args[0].req;
-                    response = args[0].res;
-                    start = args[0].start;
-                    uri = args[0].uri;
-                }
-                else {
-                    request = args[0];
-                    response = args[1];
-                    start = args[2];
-                    uri = args[3];
-                }
-
-                this.push(() => new Utils.WreckResponse(error, request, response, start, uri));
-            }.bind(this);
-        }
 
     }
 
@@ -100,7 +72,7 @@ class Monitor {
         this._ops && this._ops.start(interval);
     }
 
-    start(callback) {
+    start() {
 
         internals.forOwn(this.settings.reporters, (streamsSpec, reporterName) => {
 
@@ -130,11 +102,7 @@ class Monitor {
                 Ctor = spec.name ? Ctor[spec.name] : Ctor;
                 Hoek.assert(typeof Ctor === 'function', `Error in ${reporterName}. ${moduleName} must be a constructor function.`);
 
-                const ctorArgs = spec.args ? spec.args.slice() : [];
-                ctorArgs.unshift(null);
-
-                Ctor = Ctor.bind.apply(Ctor, ctorArgs);
-                const stream = new Ctor();
+                const stream = spec.args ? new Ctor(...spec.args) : new Ctor();
                 Hoek.assert(typeof stream.pipe === 'function', `Error in ${reporterName}. ${moduleName} must create a stream that has a pipe function.`);
 
                 streamObjs.push(stream);
@@ -155,15 +123,10 @@ class Monitor {
         this._state.report = true;
 
         // Initialize Events
-        this._server.on('log', this._logHandler);
-        this._server.on('request-error', this._errorHandler);
-        this._server.on(this.settings.responseEvent, this._responseHandler);
-        this._server.on('request', this._requestLogHandler);
-
-        if (this.settings.wreck) {
-            const wreck = Symbol.for('wreck');
-            process[wreck].on('response', this._wreckHandler);
-        }
+        this._server.events.on('log', this._logHandler);
+        this._server.events.on({ name: 'request', channels: ['error'] }, this._errorHandler);
+        this._server.events.on('response', this._responseHandler);
+        this._server.events.on({ name: 'request', channels: ['app'] }, this._requestLogHandler);
 
         if (this._ops) {
             this._ops.on('ops', this._opsHandler);
@@ -171,13 +134,11 @@ class Monitor {
         }
 
         const self = this;
-        // Events can not be any of ['log', 'request-error', 'ops', 'request', 'response', 'tail']
+        // Events can not be any of ['log', 'ops', 'request', 'response', 'tail']
         for (let i = 0; i < this.settings.extensions.length; ++i) {
             const event = this.settings.extensions[i];
-            // Can't use () => because of "arguments"
-            this._server.on(this.settings.extensions[i], function () {
+            this._server.events.on(this.settings.extensions[i], (...args) => {
 
-                const args = Array.from(arguments);
                 const payload = {
                     event,
                     timestamp: Date.now(),
@@ -186,10 +147,9 @@ class Monitor {
                 self.push(() => Object.assign({}, payload));
             });
         }
-
-        return callback();
     }
-    stop(callback) {
+
+    stop() {
 
         const state = this._state;
         state.report = false;
@@ -204,11 +164,8 @@ class Monitor {
 
             reporter.end();
         });
-
-        // Do a setImmediate here so that all the streams listening for "end" have a chance to run
-        // https://github.com/nodejs/node/blob/master/lib/_stream_readable.js#L894-L897
-        setImmediate(callback);
     }
+
     push(value) {
 
         if (this._state.report) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -24,11 +24,9 @@ exports.monitor = Joi.object().keys({
             args: Joi.array().default([])
         })
     )).default({}),
-    responseEvent: Joi.string().valid('response', 'tail').default('tail'),
-    extensions: Joi.array().items(Joi.string().invalid('log', 'request-error', 'ops', 'request', 'response', 'tail')).default([]),
+    extensions: Joi.array().items(Joi.string().invalid('log', 'ops', 'request', 'response')).default([]),
     ops: Joi.alternatives([Joi.object(), Joi.bool().allow(false)]).default({
         config: {},
         interval: 15000
-    }),
-    wreck: Joi.bool().default(false)
+    })
 }).unknown(false);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,7 +29,7 @@ class ServerLog {
 
 // Payload for "error" events
 class RequestError {
-    constructor(reqOptions, request, error) {
+    constructor(reqOptions, request, requestError) {
 
         this.event = 'error';
         this.timestamp = request.info.received;
@@ -37,7 +37,7 @@ class RequestError {
         this.url = request.url;
         this.method = request.method;
         this.pid = process.pid;
-        this.error = error;
+        this.error = requestError.error;
         this.config = internals.extractConfig(request);
 
         if (reqOptions.headers) {
@@ -47,10 +47,7 @@ class RequestError {
     toJSON() {
 
         const result = Object.assign({}, this, {
-            error: {
-                error: this.error.message,
-                stack: this.error.stack
-            }
+            error: this.error.output.payload.message
         });
         return result;
     }
@@ -59,7 +56,7 @@ class RequestError {
 
 // Payload for "response" events
 class RequestSent {
-    constructor(reqOptions, resOptions, request) {
+    constructor(reqOptions, resOptions, request, server) {
 
         const req = request.raw.req;
         const res = request.raw.res;
@@ -67,8 +64,8 @@ class RequestSent {
         this.event = 'response';
         this.timestamp = request.info.received;
         this.id = request.id;
-        this.instance = request.connection.info.uri;
-        this.labels = request.connection.settings.labels;
+        this.instance = server.info.uri;
+        this.labels = server.settings.labels;
         this.method = request.method;
         this.path = request.path;
         this.query = request.query;
@@ -85,7 +82,7 @@ class RequestSent {
         this.route = request.route.path;
 
         /* $lab:coverage:off$ */
-        this.log = (request.route.settings.log === false ? [] : request.getLog());          // Explicitly compare to false for hapi < v15
+        this.log = (request.route.settings.log === false ? [] : request.logs);          // Explicitly compare to false for hapi < v15
         /* $lab:coverage:on$ */
 
         this.tags = request.route.settings.tags;
@@ -154,41 +151,6 @@ class RequestLog {
     }
 }
 
-class WreckResponse {
-    constructor(error, request, response, start, uri) {
-
-        response = response || {};
-        uri = uri || {};
-        this.event = 'wreck';
-        this.timestamp = Date.now();
-        this.timeSpent = this.timestamp - start;
-        this.pid = process.pid;
-
-        if (error) {
-            this.error = {
-                message: error.message,
-                stack: error.stack
-            };
-        }
-
-        this.request = {
-            method: uri.method,
-            path: uri.path,
-            url: uri.href,
-            protocol: uri.protocol,
-            host: uri.host,
-            headers: request._headers
-        };
-
-        this.response = {
-            statusCode: response.statusCode,
-            statusMessage: response.statusMessage,
-            headers: response.headers
-        };
-    }
-}
-
-
 class NoOp extends Stream.Transform {
     constructor() {
 
@@ -200,6 +162,10 @@ class NoOp extends Stream.Transform {
     }
 }
 
+const timeout = function (ms) {
+
+    return new Promise((resolve) => setTimeout(resolve, ms));
+};
 
 module.exports = {
     ServerLog,
@@ -208,5 +174,5 @@ module.exports = {
     RequestLog,
     RequestSent,
     NoOp,
-    WreckResponse
+    timeout
 };

--- a/package.json
+++ b/package.json
@@ -13,23 +13,22 @@
     "plugin"
   ],
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "dependencies": {
-    "hoek": "4.x.x",
-    "joi": "10.x.x",
-    "oppsy": "1.x.x",
+    "hoek": "5.x.x",
+    "joi": "13.x.x",
+    "oppsy": "2.x.x",
     "pumpify": "1.3.x"
   },
   "peerDependencies": {
-    "hapi": ">=10.x.x"
+    "hapi": ">=17.x.x"
   },
   "devDependencies": {
-    "async": "2.5.x",
-    "code": "4.x.x",
-    "hapi": "16.x.x",
-    "lab": "14.x.x",
-    "wreck": "12.x.x"
+    "code": "5.x.x",
+    "hapi": "17.x.x",
+    "lab": "15.x.x",
+    "wreck": "14.x.x"
   },
   "scripts": {
     "test": "lab -m 5000 -t 100 -v -La code"

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -2,7 +2,6 @@
 
 // Load modules
 
-const AsyncSeries = require('async/series');
 const Code = require('code');
 const Hapi = require('hapi');
 const Lab = require('lab');
@@ -18,7 +17,6 @@ const internals = {
     monitorFactory(server, options) {
 
         const defaults = {
-            responseEvent: 'tail',
             includes: {
                 request: [],
                 response: []
@@ -28,7 +26,7 @@ const internals = {
             ops: false
         };
 
-        if (server.hasListeners === undefined) {
+        if (server.events.hasListeners === undefined) {
             const hasListeners = function (event) {
 
                 return this.listeners(event).length > 0;
@@ -54,36 +52,41 @@ const it = lab.it;
 
 describe('Monitor', () => {
 
-    it('logs an error if one occurs doing ops information collection', { plan: 2 }, (done) => {
+    it('logs an error if one occurs doing ops information collection', { plan: 1 }, () => {
 
         const monitor = internals.monitorFactory(new Hapi.Server(), { ops: { interval: 15000 } });
         const error = console.error;
-        console.error = (err) => {
 
-            console.error = error;
-            expect(err).to.be.an.instanceof(Error);
-            monitor.stop(done);
-        };
-        monitor.start((err) => {
+        return new Promise((resolve) => {
 
-            expect(err).to.not.exist();
+            console.error = (err) => {
+
+                console.error = error;
+                expect(err).to.be.an.instanceof(Error);
+                monitor.stop();
+
+                resolve();
+            };
+
+            monitor.start();
+
             monitor._ops.emit('error', new Error('mock error'));
         });
     });
 
-    it('allows starting the monitor without the ops monitoring', { plan: 2 }, (done) => {
+    it('allows starting the monitor without the ops monitoring', { plan: 1 }, () => {
 
         const monitor = internals.monitorFactory(new Hapi.Server());
-        monitor.start((err) => {
 
-            expect(err).to.not.exist();
-            monitor.startOps(100);
-            expect(monitor._ops).to.be.false();
-            monitor.stop(done);
-        });
+        monitor.start();
+
+        monitor.startOps(100);
+        expect(monitor._ops).to.be.false();
+
+        monitor.stop();
     });
 
-    it('logs and destroys a reporter in the event of a stream error', { plan: 3 }, (done) => {
+    it('logs and destroys a reporter in the event of a stream error', { plan: 3 }, () => {
 
         const one = new GoodReporter.Incrementer(1);
         const two = new GoodReporter.Writer(true);
@@ -99,31 +102,23 @@ describe('Monitor', () => {
             expect(message).to.match(/There was a problem \(.*\) in foo and it has been destroyed\./);
         };
 
-        AsyncSeries([
-            monitor.start.bind(monitor),
-            (callback) => {
+        monitor.start();
 
-                monitor.push(() => ({ id: 1, number: 2 }));
-                monitor.push(() => ({ id: 2, number: 5 }));
-                // Verion 8 of node misses this change inside monitor, so force it here
-                monitor._reporters.foo.destroyed = true;
-                monitor._reporters.foo.emit('error');
-                monitor.push(() => ({ id: 3, number: 100 }));
-                // Need this because of https://github.com/nodejs/node/pull/5251
-                setImmediate(callback);
-            }
-        ], () => {
+        monitor.push(() => ({ id: 1, number: 2 }));
+        monitor.push(() => ({ id: 2, number: 5 }));
+        // Verion 8 of node misses this change inside monitor, so force it here
+        monitor._reporters.foo.destroyed = true;
+        monitor._reporters.foo.emit('error');
+        monitor.push(() => ({ id: 3, number: 100 }));
 
-            expect(two.data).to.have.length(2);
-            expect(two.data).to.equal([{ id: 1, number: 3 }, { id: 2, number: 6 }]);
-            console.error = err;
-            done();
-        });
+        expect(two.data).to.have.length(2);
+        expect(two.data).to.equal([{ id: 1, number: 3 }, { id: 2, number: 6 }]);
+        console.error = err;
     });
 
     describe('start()', () => {
 
-        it('correctly passes dynamic arguments to stream constructors', { plan: 5 }, (done) => {
+        it('correctly passes dynamic arguments to stream constructors', { plan: 4 }, async () => {
 
             const Inc = GoodReporter.Incrementer;
             GoodReporter.Incrementer = function (starting, multiple) {
@@ -151,15 +146,14 @@ describe('Monitor', () => {
                 }
             });
 
-            monitor.start((error) => {
+            monitor.start();
 
-                expect(error).to.not.exist();
-                expect(monitor._reporters).to.have.length(1);
-                monitor.stop(done);
-            });
+            expect(monitor._reporters).to.have.length(1);
+
+            await monitor.stop();
         });
 
-        it('accepts a function as module', { plan: 2 }, (done) => {
+        it('accepts a function as module', { plan: 1 }, async () => {
 
             const monitor = internals.monitorFactory(new Hapi.Server(), {
                 reporters: {
@@ -169,15 +163,14 @@ describe('Monitor', () => {
                 }
             });
 
-            monitor.start((error) => {
+            monitor.start();
 
-                expect(error).to.not.exist();
-                expect(monitor._reporters).to.have.length(1);
-                monitor.stop(done);
-            });
+            expect(monitor._reporters).to.have.length(1);
+
+            await monitor.stop();
         });
 
-        it('accepts an unnamed function as module', { plan: 2 }, (done) => {
+        it('accepts an unnamed function as module', { plan: 1 }, () => {
 
             const monitor = internals.monitorFactory(new Hapi.Server(), {
                 reporters: {
@@ -187,15 +180,14 @@ describe('Monitor', () => {
                 }
             });
 
-            monitor.start((error) => {
+            monitor.start();
 
-                expect(error).to.not.exist();
-                expect(monitor._reporters).to.have.length(1);
-                monitor.stop(done);
-            });
+            expect(monitor._reporters).to.have.length(1);
+
+            monitor.stop();
         });
 
-        it('attaches events for "ops", "tail", "log", and "request-error"', { plan: 5 }, (done) => {
+        it('attaches events for "ops", "log", and "request"', { plan: 3 }, () => {
 
             const monitor = internals.monitorFactory(new Hapi.Server(), {
                 reporters: {
@@ -203,19 +195,17 @@ describe('Monitor', () => {
                 },
                 ops: 15000
             });
-            monitor.start((error) => {
 
-                expect(error).to.not.exist();
+            monitor.start();
 
-                expect(monitor._ops.listeners('ops')).to.have.length(1);
-                expect(monitor._server.hasListeners('request-error')).to.be.true();
-                expect(monitor._server.hasListeners('log')).to.be.true();
-                expect(monitor._server.hasListeners('tail')).to.be.true();
-                monitor.stop(done);
-            });
+            expect(monitor._ops.listeners('ops')).to.have.length(1);
+            expect(monitor._server.events.hasListeners('request')).to.be.true();
+            expect(monitor._server.events.hasListeners('log')).to.be.true();
+
+            monitor.stop();
         });
 
-        it('validates the incoming stream object instances', { plan: 2 }, (done) => {
+        it('validates the incoming stream object instances', { plan: 2 }, () => {
 
             const options = {
                 reporters: {
@@ -226,26 +216,31 @@ describe('Monitor', () => {
                 }
             };
 
-            expect(() => {
+            let monitor = internals.monitorFactory(new Hapi.Server(), options);
 
-                const monitor = internals.monitorFactory(new Hapi.Server(), options);
-                monitor.start(() => { });
-            }).to.throw(Error, 'Error in foo. ../test/fixtures/reporters must be a constructor function.');
+            try {
+                monitor.start();
+            }
+            catch (err) {
+                expect(err).to.be.an.error('Error in foo. ../test/fixtures/reporters must be a constructor function.');
+            }
 
-            expect(() => {
+            options.reporters.foo = [{
+                module: '../test/fixtures/reporters',
+                name: 'NotStream'
+            }];
 
-                options.reporters.foo = [{
-                    module: '../test/fixtures/reporters',
-                    name: 'NotStream'
-                }];
-                const monitor = internals.monitorFactory(new Hapi.Server(), options);
-                monitor.start(() => { });
-            }).to.throw(Error, 'Error in foo. ../test/fixtures/reporters must create a stream that has a pipe function.');
+            monitor = internals.monitorFactory(new Hapi.Server(), options);
 
-            done();
+            try {
+                monitor.start();
+            }
+            catch (err) {
+                expect(err).to.be.an.error('Error in foo. ../test/fixtures/reporters must create a stream that has a pipe function.');
+            }
         });
 
-        it('does not create a reporter if the reporter has no streams', { plan: 3 }, (done) => {
+        it('does not create a reporter if the reporter has no streams', { plan: 2 }, () => {
 
             const monitor = internals.monitorFactory(new Hapi.Server(), {
                 reporters: {
@@ -254,21 +249,16 @@ describe('Monitor', () => {
                 }
             });
 
-            monitor.start((error) => {
+            monitor.start();
 
-                expect(error).to.not.exist();
-
-                expect(monitor._reporters).to.have.length(1);
-                expect(monitor._reporters.bar).to.exist();
-
-                done();
-            });
+            expect(monitor._reporters).to.have.length(1);
+            expect(monitor._reporters.bar).to.exist();
         });
     });
 
     describe('push()', () => {
 
-        it('passes data through each step in the pipeline', { plan: 3 }, (done) => {
+        it('passes data through each step in the pipeline', { plan: 2 }, () => {
 
             const out1 = new GoodReporter.Writer(true);
             const out2 = new GoodReporter.Writer(true);
@@ -280,51 +270,46 @@ describe('Monitor', () => {
                 }
             });
 
-            monitor.start((error) => {
+            monitor.start();
 
-                expect(error).to.not.exist();
+            for (let i = 0; i <= 10; ++i) {
+                monitor.push(() => ({ number: i }));
+            }
 
-                for (let i = 0; i <= 10; ++i) {
-                    monitor.push(() => ({ number: i }));
-                }
+            const res1 = out1.data;
+            const res2 = out2.data;
 
-                const res1 = out1.data;
-                const res2 = out2.data;
+            expect(res1).to.equal([
+                { number: 5 },
+                { number: 6 },
+                { number: 7 },
+                { number: 8 },
+                { number: 9 },
+                { number: 10 },
+                { number: 11 },
+                { number: 12 },
+                { number: 13 },
+                { number: 14 },
+                { number: 15 }
+            ]);
 
-                expect(res1).to.equal([
-                    { number: 5 },
-                    { number: 6 },
-                    { number: 7 },
-                    { number: 8 },
-                    { number: 9 },
-                    { number: 10 },
-                    { number: 11 },
-                    { number: 12 },
-                    { number: 13 },
-                    { number: 14 },
-                    { number: 15 }
-                ]);
-
-                expect(res2).to.equal([
-                    { number: 99 },
-                    { number: 100 },
-                    { number: 101 },
-                    { number: 102 },
-                    { number: 103 },
-                    { number: 104 },
-                    { number: 105 },
-                    { number: 106 },
-                    { number: 107 },
-                    { number: 108 },
-                    { number: 109 }
-                ]);
-
-                done();
-            });
+            expect(res2).to.equal([
+                { number: 99 },
+                { number: 100 },
+                { number: 101 },
+                { number: 102 },
+                { number: 103 },
+                { number: 104 },
+                { number: 105 },
+                { number: 106 },
+                { number: 107 },
+                { number: 108 },
+                { number: 109 }
+            ]);
 
         });
 
-        it('does not push data through if the monitor has been stopped', { plan: 2 }, (done) => {
+        it('does not push data through if the monitor has been stopped', { plan: 1 }, () => {
 
             const out1 = new GoodReporter.Writer(true);
 
@@ -334,24 +319,19 @@ describe('Monitor', () => {
                 }
             });
 
-            monitor.start((error) => {
+            monitor.start();
+            monitor.stop();
 
-                expect(error).to.not.exist();
-                monitor.stop(() => {
-
-                    for (let i = 0; i <= 10; ++i) {
-                        monitor.push(() => ({ number: i }));
-                    }
-                    expect(out1.data).to.equal([]);
-                    done();
-                });
-            });
+            for (let i = 0; i <= 10; ++i) {
+                monitor.push(() => ({ number: i }));
+            }
+            expect(out1.data).to.equal([]);
         });
     });
 
     describe('stop()', () => {
 
-        it('cleans up open timeouts, stops reporting events and pushes null to the read stream', { plan: 6 }, (done) => {
+        it('cleans up open timeouts, stops reporting events and pushes null to the read stream', { plan: 6 }, async () => {
 
             const one = new GoodReporter.Incrementer(1);
             const two = new GoodReporter.Stringify();
@@ -360,43 +340,34 @@ describe('Monitor', () => {
                 reporters: {
                     foo: [one, two, three]
                 },
-                extensions: ['request-internal'],
                 ops: {
                     interval: 1500
                 }
             });
 
-            AsyncSeries([
-                monitor.start.bind(monitor),
-                (callback) => {
+            monitor.start();
 
-                    monitor.startOps(1500);
-                    return callback();
-                },
-                (callback) => {
+            monitor.startOps(1500);
 
-                    expect(monitor._state.report).to.be.true();
-                    monitor.stop(() => {
+            expect(monitor._state.report).to.be.true();
 
-                        expect(one._finalized).to.be.true();
-                        expect(two._finalized).to.be.true();
-                        expect(three._finalized).to.be.true();
-                        expect(monitor._state.report).to.be.false();
-                        expect([false, null]).to.contain(monitor._ops._interval._repeat);
-                        callback();
-                    });
-                }
-            ], done);
+            monitor.stop();
+
+            await Utils.timeout(50);
+
+            expect(one._finalized).to.be.true();
+            expect(two._finalized).to.be.true();
+            expect(three._finalized).to.be.true();
+            expect(monitor._state.report).to.be.false();
+            expect([false, null]).to.contain(monitor._ops._interval._repeat);
         });
     });
 
     describe('monitoring', () => {
 
-
-        it('sends events to all reporters when they occur', { plan: 12 }, (done) => {
+        it('sends events to all reporters when they occur', { plan: 10 }, async () => {
 
             const server = new Hapi.Server({ debug: false });
-            server.connection();
 
             server.route({
                 method: 'GET',
@@ -405,11 +376,11 @@ describe('Monitor', () => {
                     plugins: {
                         good: { foo: 'bar' }
                     },
-                    handler: (request, reply) => {
+                    handler: (request, h) => {
 
                         request.log('test-tag', 'log request data');
                         server.log(['test'], 'test data');
-                        reply('done');
+
                         throw new Error('mock error');
                     }
                 }
@@ -417,122 +388,105 @@ describe('Monitor', () => {
 
             const out1 = new GoodReporter.Writer(true);
             const out2 = new GoodReporter.Writer(true);
-            // remove these keys so deep.equal works. they change call to call and machine to machine
-            const filters = ['timestamp', 'pid', 'id', 'log', 'responseTime', 'source'];
             const monitor = internals.monitorFactory(server, {
                 reporters: {
                     foo: [
                         new GoodReporter.Namer('foo'),
-                        new GoodReporter.Cleaner(filters),
                         out1
                     ],
                     bar: [
-                        new GoodReporter.Cleaner(filters),
                         out2
                     ]
                 }
             });
 
-            AsyncSeries([
-                server.start.bind(server),
-                monitor.start.bind(monitor),
-                (callback) => {
+            await server.start();
 
-                    Wreck.get(server.info.uri + '/?q=test', (err, res) => {
+            monitor.start();
 
-                        // Wreck v11+ report 4xx & 5xx as errors
-                        const isWreckVersion11OrHigher = (err && err.isBoom);
-                        if (isWreckVersion11OrHigher) {
-                            expect(err).to.exist();
-                            expect(err.output.payload.statusCode).to.equal(500);
-                        }
-                        else {
-                            expect(err).to.not.exist();
-                            expect(res.statusCode).to.equal(500);
-                        }
+            try {
+                await Wreck.get(server.info.uri + '/?q=test');
+            }
+            catch (err) {
+                expect(err).to.exist();
+                expect(err.output.payload.statusCode).to.equal(500);
 
-                        setTimeout(() => {
+                await Utils.timeout(50);
 
-                            const res1 = out1.data;
-                            const res2 = out2.data;
+                const res1 = out1.data;
+                const res2 = out2.data;
 
-                            expect(res1).to.have.length(4);
-                            expect(res1).to.part.contain([{
-                                event: 'request',
-                                tags: ['test-tag'],
-                                data: 'log request data',
-                                method: 'get',
-                                path: '/',
-                                config: { foo: 'bar' },
-                                name: 'foo'
-                            }, {
-                                event: 'log',
-                                tags: ['test'],
-                                data: 'test data',
-                                name: 'foo'
-                            }, {
-                                event: 'response',
-                                instance: server.info.uri,
-                                labels: [],
-                                method: 'get',
-                                path: '/',
-                                query: { q: 'test' },
-                                statusCode: 500,
-                                config: { foo: 'bar' },
-                                name: 'foo'
-                            }]);
+                expect(res1).to.have.length(4);
+                expect(res1).to.part.contain([{
+                    event: 'request',
+                    tags: ['test-tag'],
+                    data: 'log request data',
+                    method: 'get',
+                    path: '/',
+                    config: { foo: 'bar' },
+                    name: 'foo'
+                }, {
+                    event: 'log',
+                    tags: ['test'],
+                    data: 'test data',
+                    name: 'foo'
+                }, {
+                    event: 'response',
+                    instance: server.info.uri,
+                    labels: [],
+                    method: 'get',
+                    path: '/',
+                    query: { q: 'test' },
+                    statusCode: 500,
+                    config: { foo: 'bar' },
+                    name: 'foo'
+                }]);
 
-                            const err1 = JSON.parse(JSON.stringify(res1[2]));
-                            expect(err1.event).to.equal('error');
-                            expect(err1.error.error).to.equal('Uncaught error: mock error');
-                            expect(err1.error.stack.split('\n')[0]).to.equal('Error: Uncaught error: mock error');
+                const err1 = JSON.parse(JSON.stringify(res1[2]));
+                expect(err1.event).to.equal('error');
+                expect(err1.error).to.equal('An internal server error occurred');
 
-                            expect(res2).to.have.length(4);
-                            expect(res2).to.part.contain([{
-                                event: 'request',
-                                tags: ['test-tag'],
-                                data: 'log request data',
-                                method: 'get',
-                                path: '/',
-                                config: { foo: 'bar' }
-                            }, {
-                                event: 'log',
-                                tags: ['test'],
-                                data: 'test data'
-                            }, {
-                                event: 'response',
-                                instance: server.info.uri,
-                                labels: [],
-                                method: 'get',
-                                path: '/',
-                                query: { q: 'test' },
-                                statusCode: 500,
-                                config: { foo: 'bar' }
-                            }]);
+                expect(res2).to.have.length(4);
+                expect(res2).to.part.contain([{
+                    event: 'request',
+                    tags: ['test-tag'],
+                    data: 'log request data',
+                    method: 'get',
+                    path: '/',
+                    config: { foo: 'bar' }
+                }, {
+                    event: 'log',
+                    tags: ['test'],
+                    data: 'test data'
+                }, {
+                    event: 'response',
+                    instance: server.info.uri,
+                    labels: [],
+                    method: 'get',
+                    path: '/',
+                    query: { q: 'test' },
+                    statusCode: 500,
+                    config: { foo: 'bar' }
+                }]);
 
-                            const err2 = JSON.parse(JSON.stringify(res1[2]));
-                            expect(err2.event).to.equal('error');
-                            expect(err2.error.error).to.equal('Uncaught error: mock error');
-                            expect(err2.error.stack.split('\n')[0]).to.equal('Error: Uncaught error: mock error');
-
-                            callback();
-                        }, 50);
-                    });
-                }
-            ], done);
+                const err2 = JSON.parse(JSON.stringify(res1[2]));
+                expect(err2.event).to.equal('error');
+                expect(err1.error).to.equal('An internal server error occurred');
+            }
         });
 
-        it('provides additional information about "response" events using "requestHeaders","requestPayload", and "responsePayload"', { plan: 9 }, (done) => {
+        it('provides additional information about "response" events using "requestHeaders","requestPayload", and "responsePayload"', { plan: 8 }, async () => {
 
             const server = new Hapi.Server();
-            server.connection();
+
             server.route({
                 method: 'POST',
                 path: '/',
-                handler: (request, reply) => {
+                handler: (request, h) => {
 
                     server.log(['test'], 'test data');
-                    reply('done');
+
+                    return 'done';
                 }
             });
 
@@ -547,48 +501,43 @@ describe('Monitor', () => {
                 }
             });
 
-            AsyncSeries([
-                server.start.bind(server),
-                monitor.start.bind(monitor),
-                (callback) => {
+            await server.start();
+            monitor.start();
 
-                    Wreck.post(server.info.uri + '/?q=test', {
-                        headers: {
-                            'Content-Type': 'application/json'
-                        },
-                        payload: JSON.stringify({
-                            data: 'example payload'
-                        })
-                    }, (err, res) => {
+            const res = await Wreck.request('post', server.info.uri + '/?q=test', {
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                payload: JSON.stringify({
+                    data: 'example payload'
+                }),
+                timeout: 200
+            });
 
-                        expect(err).to.not.exist();
-                        expect(res.statusCode).to.equal(200);
-                        setTimeout(() => {
+            expect(res.statusCode).to.equal(200);
 
-                            const messages = out.data;
-                            const response = messages[1];
+            await Utils.timeout(50);
 
-                            expect(messages).to.have.length(2);
+            const messages = out.data;
+            const response = messages[1];
 
-                            expect(response.event).to.equal('response');
-                            expect(response.log).to.be.an.array();
-                            expect(response.headers).to.exist();
-                            expect(response.requestPayload).to.equal({
-                                data: 'example payload'
-                            });
-                            expect(response.responsePayload).to.equal('done');
-                            expect(response.route).to.equal('/');
-                            server.stop(callback);
-                        }, 50);
-                    });
-                }
-            ], done);
+            expect(messages).to.have.length(2);
+
+            expect(response.event).to.equal('response');
+            expect(response.log).to.be.an.array();
+            expect(response.headers).to.exist();
+            expect(response.requestPayload).to.equal({
+                data: 'example payload'
+            });
+            expect(response.responsePayload).to.equal('done');
+            expect(response.route).to.equal('/');
+
+            await server.stop();
         });
 
-        it('has a standard "ops" data object', { plan: 2 }, (done) => {
+        it('has a standard "ops" data object', { plan: 2 }, async () => {
 
             const server = new Hapi.Server();
-            server.connection();
 
             const out = new GoodReporter.Writer(true);
             const monitor = internals.monitorFactory(server, {
@@ -600,78 +549,68 @@ describe('Monitor', () => {
                 }
             });
 
-            AsyncSeries([
-                server.start.bind(server),
-                monitor.start.bind(monitor),
-                (callback) => {
 
-                    monitor.startOps(100);
-                    return callback();
-                },
-                (callback) => {
+            await server.start();
 
-                    // Give the reporters time to report
-                    setTimeout(() => {
+            monitor.start();
 
-                        expect(out.data).to.have.length(1);
+            monitor.startOps(100);
 
-                        const event = out.data[0];
-                        expect(event).to.be.an.instanceof(Utils.Ops);
-                        server.stop(callback);
-                    }, 150);
-                }
-            ], done);
+            // Give the reporters time to report
+            await Utils.timeout(150);
+
+            expect(out.data).to.have.length(1);
+
+            const event = out.data[0];
+            expect(event).to.be.an.instanceof(Utils.Ops);
+
+            await server.stop();
         });
 
-        it('has a standard "response" data object', { plan: 3 }, (done) => {
+        it('has a standard "response" data object', { plan: 3 }, async () => {
 
             const server = new Hapi.Server();
-            server.connection({ labels: ['test', 'foo'] });
 
             server.route({
                 method: 'GET',
                 path: '/',
-                handler: (request, reply) => {
+                handler: (request, h) => {
 
-                    reply().code(201);
+                    return h.response().code(201);
                 }
             });
 
             const out = new GoodReporter.Writer(true);
             const monitor = internals.monitorFactory(server, { reporters: { foo: [out] } });
 
-            AsyncSeries([
-                server.start.bind(server),
-                monitor.start.bind(monitor),
-                (callback) => {
+            await server.start();
 
-                    server.inject({
-                        url: '/'
-                    }, (res) => {
+            monitor.start();
 
-                        expect(res.statusCode).to.equal(201);
-                        setTimeout(() => {
+            const res = await server.inject({
+                url: '/'
+            });
 
-                            expect(out.data).to.have.length(1);
+            expect(res.statusCode).to.equal(201);
 
-                            const event = out.data[0];
-                            expect(event).to.be.an.instanceof(Utils.RequestSent);
-                            server.stop(callback);
-                        }, 50);
-                    });
-                }
-            ], done);
+            await Utils.timeout(50);
+
+            expect(out.data).to.have.length(1);
+
+            const event = out.data[0];
+            expect(event).to.be.an.instanceof(Utils.RequestSent);
+
+            await server.stop();
         });
 
-        it('has a standard "error" data object', { plan: 3 }, (done) => {
+        it('has a standard "error" data object', { plan: 3 }, async () => {
 
             const server = new Hapi.Server({ debug: false });
-            server.connection();
 
             server.route({
                 method: 'GET',
                 path: '/',
-                handler: (request, reply) => {
+                handler: (request, h) => {
 
                     throw new Error('mock error');
                 }
@@ -680,38 +619,34 @@ describe('Monitor', () => {
             const out = new GoodReporter.Writer(true);
             const monitor = internals.monitorFactory(server, { reporters: { foo: [out] } });
 
-            AsyncSeries([
-                server.start.bind(server),
-                monitor.start.bind(monitor),
-                (callback) => {
+            await server.start();
 
-                    server.inject({
-                        url: '/'
-                    }, (res) => {
+            monitor.start();
 
-                        expect(res.statusCode).to.equal(500);
-                        setTimeout(() => {
+            const res = await server.inject({
+                url: '/'
+            });
 
-                            expect(out.data).to.have.length(2);
+            expect(res.statusCode).to.equal(500);
 
-                            const event = out.data[0];
-                            expect(event).to.be.an.instanceof(Utils.RequestError);
-                            server.stop(callback);
-                        }, 50);
-                    });
-                }
-            ], done);
+            await Utils.timeout(50);
+
+            expect(out.data).to.have.length(2);
+
+            const event = out.data[0];
+            expect(event).to.be.an.instanceof(Utils.RequestError);
+
+            await server.stop();
         });
 
-        it('includes headers in the "error" data object if so configured', { plan: 3 }, (done) => {
+        it('includes headers in the "error" data object if so configured', { plan: 3 }, async () => {
 
             const server = new Hapi.Server({ debug: false });
-            server.connection();
 
             server.route({
                 method: 'GET',
                 path: '/',
-                handler: (request, reply) => {
+                handler: (request, h) => {
 
                     throw new Error('mock error');
                 }
@@ -726,128 +661,119 @@ describe('Monitor', () => {
                 reporters: { foo: [out] }
             });
 
-            AsyncSeries([
-                server.start.bind(server),
-                monitor.start.bind(monitor),
-                (callback) => {
+            await server.start();
 
-                    server.inject({
-                        url: '/',
-                        headers: {
-                            'X-Magic-Value': 'rabbits out of hats'
-                        }
-                    }, (res) => {
+            monitor.start();
 
-                        expect(res.statusCode).to.equal(500);
-                        setTimeout(() => {
-
-                            expect(out.data).to.have.length(2);
-
-                            const event = out.data[1];
-                            expect(event.headers['x-magic-value']).to.equal('rabbits out of hats');
-                            server.stop(callback);
-                        }, 50);
-                    });
+            const res = await server.inject({
+                url: '/',
+                headers: {
+                    'X-Magic-Value': 'rabbits out of hats'
                 }
-            ], done);
+            });
+
+            expect(res.statusCode).to.equal(500);
+
+            await Utils.timeout(50);
+
+            expect(out.data).to.have.length(2);
+
+            const event = out.data[1];
+            expect(event.headers['x-magic-value']).to.equal('rabbits out of hats');
+
+            await server.stop();
         });
 
-        it('has a standard "log" data object', { plan: 3 }, (done) => {
+        it('has a standard "log" data object', { plan: 3 }, async () => {
 
             const server = new Hapi.Server();
-            server.connection();
 
             server.route({
                 method: 'GET',
                 path: '/',
-                handler: (request, reply) => {
+                handler: (request, h) => {
 
                     server.log(['user', 'success'], 'route route called');
-                    reply();
+
+                    return 'ok';
                 }
             });
 
             const out = new GoodReporter.Writer(true);
             const monitor = internals.monitorFactory(server, { reporters: { foo: [out] } });
 
-            AsyncSeries([
-                server.start.bind(server),
-                monitor.start.bind(monitor),
-                (callback) => {
+            await server.start();
 
-                    server.inject({
-                        url: '/'
-                    }, (res) => {
+            monitor.start();
 
-                        expect(res.statusCode).to.equal(200);
-                        setTimeout(() => {
+            const res = await server.inject({
+                url: '/'
+            });
 
-                            expect(out.data).to.have.length(2);
+            expect(res.statusCode).to.equal(200);
 
-                            const event = out.data[0];
+            await Utils.timeout(50);
 
-                            expect(event).to.be.an.instanceof(Utils.ServerLog);
-                            server.stop(callback);
-                        }, 50);
-                    });
-                }
-            ], done);
+            expect(out.data).to.have.length(2);
+
+            const event = out.data[0];
+
+            expect(event).to.be.an.instanceof(Utils.ServerLog);
+
+            await server.stop();
         });
 
-        it('has a standard "request" event schema', { plan: 3 }, (done) => {
+        it('has a standard "request" event schema', { plan: 3 }, async () => {
 
             const server = new Hapi.Server();
-            server.connection();
 
             server.route({
                 method: 'GET',
                 path: '/',
-                handler: (request, reply) => {
+                handler: (request, h) => {
 
                     request.log(['user', 'test'], 'you called the / route');
-                    reply();
+
+                    return 'ok';
                 }
             });
 
             const out = new GoodReporter.Writer(true);
             const monitor = internals.monitorFactory(server, { reporters: { foo: [out] } });
 
-            AsyncSeries([
-                server.start.bind(server),
-                monitor.start.bind(monitor),
-                (callback) => {
+            await server.start();
 
-                    server.inject({
-                        url: '/'
-                    }, (res) => {
+            monitor.start();
 
-                        expect(res.statusCode).to.equal(200);
-                        setTimeout(() => {
+            const res = await server.inject({
+                url: '/'
+            });
 
-                            expect(out.data).to.have.length(2);
+            expect(res.statusCode).to.equal(200);
 
-                            const event = out.data[0];
+            await Utils.timeout(50);
 
-                            expect(event).to.be.an.instanceof(Utils.RequestLog);
-                            server.stop(callback);
-                        }, 50);
-                    });
-                }
-            ], done);
+            expect(out.data).to.have.length(2);
+
+            const event = out.data[0];
+
+            expect(event).to.be.an.instanceof(Utils.RequestLog);
+
+            await server.stop();
         });
 
-        it('includes headers in data object if so configured', { plan: 3 }, (done) => {
+        it('includes headers in data object if so configured', { plan: 3 }, async () => {
 
             const server = new Hapi.Server();
-            server.connection();
 
             server.route({
                 method: 'GET',
                 path: '/',
-                handler: (request, reply) => {
+                handler: (request, h) => {
 
                     request.log(['user', 'test'], 'you called the / route');
-                    reply();
+
+                    return 'ok';
                 }
             });
 
@@ -860,52 +786,48 @@ describe('Monitor', () => {
                 reporters: { foo: [out] }
             });
 
-            AsyncSeries([
-                server.start.bind(server),
-                monitor.start.bind(monitor),
-                (callback) => {
+            await server.start();
 
-                    server.inject({
-                        url: '/',
-                        headers: {
-                            'X-TraceID': 'ABCD12345'
-                        }
-                    }, (res) => {
+            monitor.start();
 
-                        expect(res.statusCode).to.equal(200);
-                        setTimeout(() => {
-
-                            expect(out.data).to.have.length(2);
-
-                            const event = out.data[1];
-
-                            expect(event.headers['x-traceid']).to.equal('ABCD12345');
-                            server.stop(callback);
-                        }, 50);
-                    });
+            const res = await server.inject({
+                url: '/',
+                headers: {
+                    'X-TraceID': 'ABCD12345'
                 }
-            ], done);
+            });
+
+            expect(res.statusCode).to.equal(200);
+
+            await Utils.timeout(50);
+
+            expect(out.data).to.have.length(2);
+
+            const event = out.data[1];
+
+            expect(event.headers['x-traceid']).to.equal('ABCD12345');
+
+            await server.stop();
         });
 
-        it('reports extension events when they occur', { plan: 14 }, (done) => {
+        it('reports extension events when they occur', { plan: 6 }, async () => {
 
             const server = new Hapi.Server();
-            server.connection();
 
             server.route({
                 method: 'GET',
                 path: '/',
-                handler: (request, reply) => {
+                handler: (request, h) => {
 
                     // Simulate a new event that might exist down the road
-                    server._events.emit('super-secret', {
+                    server.events.emit('super-secret', {
                         id: 1,
                         foo: 'bar'
                     });
 
-                    server._events.emit('super-secret', null);
+                    server.events.emit('super-secret', null);
 
-                    reply();
+                    return 'ok';
                 }
             });
 
@@ -914,76 +836,62 @@ describe('Monitor', () => {
                 reporters: {
                     foo: [new GoodReporter.Cleaner('timestamp'), out]
                 },
-                extensions: ['start', 'stop', 'request-internal', 'super-secret']
+                extensions: ['start', 'stop', { name: 'request', channels: ['internal'] }, 'super-secret']
             });
 
-            AsyncSeries([
-                monitor.start.bind(monitor),
-                server.start.bind(server),
-                (callback) => {
+            monitor.start();
 
-                    server.inject({
-                        url: '/'
-                    }, () => {
+            await server.start();
 
-                        callback();
-                    });
-                },
-                server.stop.bind(server),
-                (callback) => setTimeout(callback, 100),
-                (callback) => {
+            await server.inject({
+                url: '/'
+            });
 
-                    expect(out.data).to.have.length(8);
+            await server.stop();
 
-                    const hapi15 = (server.event !== undefined);
+            await Utils.timeout(100);
 
-                    expect(out.data[0].event).to.equal('start');
-                    const internalEvents = [1, (hapi15 ? 3 : 4), 5];
+            expect(out.data).to.have.length(5);
 
-                    for (let i = 0; i < internalEvents.length; ++i) {
-                        const index = internalEvents[i];
-                        const event = out.data[index];
+            expect(out.data[0].event).to.equal('start');
 
-                        expect(event.event).to.equal('request-internal');
-                        expect(event.payload).to.have.length(3);
-                        expect(event.payload[1].internal).to.be.true();
-                    }
+            expect(out.data[1]).to.equal({
+                event: 'super-secret',
+                payload: [{
+                    id: 1,
+                    foo: 'bar'
+                }]
+            });
 
-                    expect(out.data[2]).to.equal({
-                        event: 'super-secret',
-                        payload: [{
-                            id: 1,
-                            foo: 'bar'
-                        }]
-                    });
+            expect(out.data[2]).to.equal({
+                event: 'super-secret',
+                payload: [null]
+            });
 
-                    expect(out.data[hapi15 ? 4 : 3]).to.equal({
-                        event: 'super-secret',
-                        payload: [null]
-                    });
+            expect(out.data[3].event).to.equal('response');
 
-                    expect(out.data[hapi15 ? 6 : 7].event).to.equal('stop');
-                    callback();
-                }
-            ], done);
+            expect(out.data[4].event).to.equal('stop');
+
         });
 
-        it('attaches good data from the request.plugins.good and route good config to reporting objects', { plan: 3 }, (done) => {
+        it('attaches good data from the request.plugins.good and route good config to reporting objects', { plan: 3 }, async () => {
 
             const server = new Hapi.Server();
-            server.connection();
+
             server.route({
                 path: '/',
                 method: 'GET',
                 config: {
-                    handler(request, reply) {
+                    handler(request, h) {
 
                         request.plugins.good = {
                             foo: 'baz',
                             filter: true
                         };
-                        reply();
+
                         request.log(['test', { test: true }]);
+
+                        return 'ok';
                     },
                     plugins: {
                         good: {
@@ -997,35 +905,29 @@ describe('Monitor', () => {
             const out = new GoodReporter.Writer(true);
             const monitor = internals.monitorFactory(server, { reporters: { foo: [out] } });
 
-            AsyncSeries([
-                monitor.start.bind(monitor),
-                (callback) => {
+            monitor.start();
 
-                    server.inject({
-                        url: server.info.uri
-                    }, (res) => {
+            const res = await server.inject({
+                url: server.info.uri
+            });
 
-                        expect(res.statusCode).to.equal(200);
-                        setTimeout(() => {
+            expect(res.statusCode).to.equal(200);
 
-                            expect(out.data[0].config).to.equal({
-                                foo: 'baz',
-                                filter: true,
-                                zip: 'zap'
-                            });
-                            expect(out.data[1].config).to.equal({
-                                foo: 'baz',
-                                filter: true,
-                                zip: 'zap'
-                            });
-                            callback();
-                        }, 50);
-                    });
-                }
-            ], done);
+            await Utils.timeout(50);
+
+            expect(out.data[0].config).to.equal({
+                foo: 'baz',
+                filter: true,
+                zip: 'zap'
+            });
+            expect(out.data[1].config).to.equal({
+                foo: 'baz',
+                filter: true,
+                zip: 'zap'
+            });
         });
 
-        it('can communicate with process.stdout and process.stderr', { plan: 6 }, (done) => {
+        it('can communicate with process.stdout and process.stderr', { plan: 6 }, async () => {
 
             const replace = (orig, dest) => {
 
@@ -1061,117 +963,25 @@ describe('Monitor', () => {
                 }
             });
 
-            AsyncSeries([
-                monitor.start.bind(monitor),
-                (callback) => {
+            monitor.start();
 
-                    monitor.startOps(100);
-                    setTimeout(callback, 250);
-                },
-                monitor.stop.bind(monitor),
-                (callback) => {
+            monitor.startOps(100);
 
-                    process.stdout.write = write;
-                    process.stderr.write = err;
+            await Utils.timeout(250);
 
-                    expect(writeData.length).to.be.above(1);
-                    expect(writeData[0]).to.include(['event', 'timestamp', 'host', 'pid', 'os', 'proc', 'load']);
-                    expect(writeData[0].name).to.equal('foo');
+            monitor.stop();
 
-                    expect(errData.length).to.be.above(1);
-                    expect(errData[0]).to.include(['event', 'timestamp', 'host', 'pid', 'os', 'proc', 'load']);
-                    expect(errData[0].name).to.equal('bar');
+            process.stdout.write = write;
+            process.stderr.write = err;
 
-                    callback();
-                }
-            ], done);
-        });
+            expect(writeData.length).to.be.above(1);
+            expect(writeData[0]).to.include(['event', 'timestamp', 'host', 'pid', 'os', 'proc', 'load']);
+            expect(writeData[0].name).to.equal('foo');
 
-        it('has a standard "wreck" event schema for version 10 and below', { plan: 3 }, (done) => {
+            expect(errData.length).to.be.above(1);
+            expect(errData[0]).to.include(['event', 'timestamp', 'host', 'pid', 'os', 'proc', 'load']);
+            expect(errData[0].name).to.equal('bar');
 
-            const server = new Hapi.Server();
-            server.connection();
-
-            server.route({
-                method: 'GET',
-                path: '/',
-                handler: (request, reply) => {
-
-                    Wreck.get(server.info.uri + '/test', (err, res) => {
-
-                        reply(err, res);
-                    });
-                }
-            });
-
-            server.route({
-                method: 'GET',
-                path: '/test',
-                handler: (request, reply) => {
-
-                    reply();
-                }
-            });
-
-            const out = new GoodReporter.Writer(true);
-            const monitor = internals.monitorFactory(server, {
-                reporters: { foo: [out] },
-                wreck: true
-            });
-
-            AsyncSeries([
-                server.start.bind(server),
-                monitor.start.bind(monitor),
-                (callback) => {
-
-                    server.inject({
-                        url: '/'
-                    }, (res) => {
-
-                        expect(res.statusCode).to.equal(200);
-                        // account for hapi15 differences
-                        expect(out.data.length).to.be.greaterThan(0);
-                        const result = out.data.find((event) => {
-
-                            return event.event === 'wreck';
-                        });
-                        expect(result).to.be.an.instanceof(Utils.WreckResponse);
-                        server.stop(callback);
-                    });
-                }
-            ], done);
-        });
-
-        it('has a standard "wreck" event schema for version 10', { plan: 2 }, (done) => {
-
-            const server = new Hapi.Server();
-            server.connection();
-
-            const out = new GoodReporter.Writer(true);
-            const monitor = internals.monitorFactory(server, {
-                reporters: { foo: [out] },
-                wreck: true
-            });
-
-            AsyncSeries([
-                server.start.bind(server),
-                monitor.start.bind(monitor),
-                (callback) => {
-
-                    // Manually emit Wreck 11+ style event to prevent complexity of duplicate wreck versions in a test suite.
-                    const wreck = Symbol.for('wreck');
-                    process[wreck].emit('response', null, {}, {}, 0, {});
-
-                    expect(out.data.length).to.be.greaterThan(0);
-                    const result = out.data.find((event) => {
-
-                        return event.event === 'wreck';
-                    });
-                    expect(result).to.be.an.instanceof(Utils.WreckResponse);
-
-                    server.stop(callback);
-                }
-            ], done);
         });
     });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -46,17 +46,15 @@ describe('utils', () => {
             },
             query: {},
             responseTime: 123,
-            connection: {
-                settings: {
-                    labels: []
-                },
-                info: {
-                    uri: 'http://localhost:3000'
-                }
-            },
-            getLog: () => {
+            logs: {}
+        };
 
-                return {};
+        const _server = {
+            settings: {
+                labels: []
+            },
+            info: {
+                uri: 'http://localhost:3000'
             }
         };
 
@@ -77,10 +75,10 @@ describe('utils', () => {
                 source: responsePayload
             };
 
-            return new Utils.RequestSent(reqOpts, resOpts, request);
+            return new Utils.RequestSent(reqOpts, resOpts, request, _server);
         };
 
-        it('handles response payloads with a toString() function', { plan: 2 }, (done) => {
+        it('handles response payloads with a toString() function', { plan: 2 }, () => {
 
             const samplePayload = {
                 message: 'test',
@@ -93,13 +91,12 @@ describe('utils', () => {
             expect(req.requestPayload).to.equal(samplePayload);
             const res = generateRequestSent('', samplePayload);
             expect(res.responsePayload).to.equal(samplePayload);
-            done();
         });
     });
 
     describe('RequestError()', () => {
 
-        it('can be stringifyed', { plan: 2 }, (done) => {
+        it('can be stringifyed', { plan: 1 }, () => {
 
             const err = new Utils.RequestError({}, {
                 id: 15,
@@ -109,42 +106,25 @@ describe('utils', () => {
                 info: {
                     received: Date.now()
                 }
-            }, new Error('mock error'));
+            }, {
+                'error': {
+                    isBoom: true,
+                    isServer: true,
+                    data: null,
+                    output: {
+                        statusCode: 500,
+                        payload: {
+                            statusCode: 500,
+                            error: 'Internal Server Error',
+                            message: 'An internal server error occurred'
+                        },
+                        headers: {}
+                    }
+                }
+            });
 
             const parse = JSON.parse(JSON.stringify(err));
-            expect(parse.error).to.be.an.object();
-            expect(parse.error.stack).to.be.a.string();
-            done();
-        });
-    });
-
-    describe('WreckResponse()', () => {
-
-        const keysUndefined = (obj) => {
-
-            const keys = Object.keys(obj);
-            for (let i = 0; i < keys.length; ++i) {
-                const key = keys[i];
-                expect(obj[key]).to.be.undefined();
-            }
-        };
-
-        it('creates a default response and uri values in case they are missing', (done) => {
-
-            const wreckValue = new Utils.WreckResponse(null, {}, null, Date.now());
-            keysUndefined(wreckValue.request);
-            keysUndefined(wreckValue.response);
-            expect(wreckValue.event).to.equal('wreck');
-            expect(wreckValue.timeSpent).to.be.a.number();
-            done();
-        });
-
-        it('attaches an error object in the event of a wreck error', (done) => {
-
-            const wreckValue = new Utils.WreckResponse(new Error('test error'), {}, null, Date.now());
-            expect(wreckValue.error.stack).to.be.a.string();
-            expect(wreckValue.error.message).to.equal('test error');
-            done();
+            expect(parse.error).to.equal('An internal server error occurred');
         });
     });
 });


### PR DESCRIPTION
Migrates to hapi 17, node 8 and async/await

I removed wreck support as wreck no longer issues the events needed

I am still trying to solve an issue where the tests emit ` MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 end listeners added. Use emitter.setMaxListeners() to increase limit`

Any comments and help would be appreciated 