### PR TITLE
request.id is now request.info.id since Hapi 17

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,7 +33,7 @@ class RequestError {
 
         this.event = 'error';
         this.timestamp = request.info.received;
-        this.id = request.id;
+        this.id = request.info.id;
         this.url = request.url;
         this.method = request.method;
         this.pid = process.pid;
@@ -63,7 +63,7 @@ class RequestSent {
 
         this.event = 'response';
         this.timestamp = request.info.received;
-        this.id = request.id;
+        this.id = request.info.id;
         this.instance = server.info.uri;
         this.labels = server.settings.labels;
         this.method = request.method;
@@ -139,7 +139,7 @@ class RequestLog {
         this.tags = event.tags;
         this.data = event.data;
         this.pid = process.pid;
-        this.id = request.id;
+        this.id = request.info.id;
         this.method = request.method;
         this.path = request.path;
         this.config = internals.extractConfig(request);

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -568,7 +568,7 @@ describe('Monitor', () => {
             await server.stop();
         });
 
-        it('has a standard "response" data object', { plan: 3 }, async () => {
+        it('has a standard "response" data object', { plan: 4 }, async () => {
 
             const server = new Hapi.Server();
 
@@ -599,7 +599,9 @@ describe('Monitor', () => {
             expect(out.data).to.have.length(1);
 
             const event = out.data[0];
+
             expect(event).to.be.an.instanceof(Utils.RequestSent);
+            expect(event.id).to.be.a.string();
 
             await server.stop();
         });
@@ -685,7 +687,7 @@ describe('Monitor', () => {
             await server.stop();
         });
 
-        it('has a standard "log" data object', { plan: 3 }, async () => {
+        it('has a standard "log" data object', { plan: 4 }, async () => {
 
             const server = new Hapi.Server();
 
@@ -718,13 +720,15 @@ describe('Monitor', () => {
             expect(out.data).to.have.length(2);
 
             const event = out.data[0];
+            const request = out.data[1];
 
             expect(event).to.be.an.instanceof(Utils.ServerLog);
+            expect(request.id).to.be.a.string();
 
             await server.stop();
         });
 
-        it('has a standard "request" event schema', { plan: 3 }, async () => {
+        it('has a standard "request" event schema', { plan: 4 }, async () => {
 
             const server = new Hapi.Server();
 
@@ -759,6 +763,8 @@ describe('Monitor', () => {
             const event = out.data[0];
 
             expect(event).to.be.an.instanceof(Utils.RequestLog);
+
+            expect(event.id).to.be.a.string();
 
             await server.stop();
         });


### PR DESCRIPTION
Since Hapi 17, request.id was moved to request.info.id.

Source: https://github.com/hapijs/hapi/issues/3658

> Moved request.id to request.info.id.