### PR TITLE
Add support for request event error field

### DIFF
--- a/API.md
+++ b/API.md
@@ -234,6 +234,7 @@ Event object associated with the "request" event. This is the hapi event emitter
 - `timestamp` - timestamp of the incoming `event` object.
 - `tags` - array of strings representing any tags associated with the 'log' event.
 - `data` - the string or object mapped to `event.data`.
+- `error` - the error instance mapped to `event.error`.
 - `pid` - the current process id.
 - `id` - id of the request, maps to `request.id`.
 - `method` - method used by the request. Maps to `request.method`.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -138,6 +138,7 @@ class RequestLog {
         this.timestamp = event.timestamp;
         this.tags = event.tags;
         this.data = event.data;
+        this.error = event.error;
         this.pid = process.pid;
         this.id = request.info.id;
         this.method = request.method;

--- a/test/utils.js
+++ b/test/utils.js
@@ -94,6 +94,56 @@ describe('utils', () => {
         });
     });
 
+    describe('RequestLog()', () => {
+
+        it('accepts error on the event object when data is not present', { plan: 2 }, () => {
+
+            const errorInstance = new Error('This is a test');
+
+            const err = new Utils.RequestLog({}, {
+                info: {
+                    id: 32
+                },
+                method: 'post',
+                path: '/graph',
+                config: {}
+            }, {
+                event: 'request',
+                timestamp: 1517592924723,
+                tags: ['error', 'authentication'],
+                error: errorInstance
+            });
+
+            expect(err.error).to.equal(errorInstance);
+            expect(err.data).to.be.undefined();
+
+        });
+
+        it('accepts data on the event object when error is not present', { plan: 2 }, () => {
+
+            const sampleData = { foo: 'bar' };
+
+            const err = new Utils.RequestLog({}, {
+                info: {
+                    id: 32
+                },
+                method: 'post',
+                path: '/graph',
+                config: {}
+            }, {
+                event: 'request',
+                timestamp: 1517592924723,
+                tags: ['error', 'authentication'],
+                data: sampleData
+            });
+
+            expect(err.data).to.equal(sampleData);
+            expect(err.error).to.be.undefined();
+
+        });
+
+    });
+
     describe('RequestError()', () => {
 
         it('can be stringifyed', { plan: 1 }, () => {


### PR DESCRIPTION
Hapi has some logic that decides whether to include `error` or `data` on the request event object. It does this by simply checking if the log data is an instance of an Error object. This adds support for propagating that field properly. If you pass an error object right now as data, Good is completely unaware of it and simply drops it.

https://github.com/hapijs/hapi/blob/master/lib/core.js#L556-L558
