### PR TITLE
Add support for logging response headers

### DIFF
--- a/API.md
+++ b/API.md
@@ -21,7 +21,7 @@ as general events are a process-wide facility and will result in duplicated log 
 ## Options
 - `[includes]` - optional configuration object
     - `[request]` - array of extra hapi request object fields to supply to reporters on "request", "response", and "error" events. Valid values ['headers', 'payload']. Defaults to `[]`.
-    - `[response]` - array of extra hapi response object fields to supply to reporters on "response" events. Valid values ['payload']. Defaults to `[]`.
+    - `[response]` - array of extra hapi response object fields to supply to reporters on "response" events. Valid values ['headers', 'payload']. Defaults to `[]`.
 - `[ops]` - options for controlling the ops reporting from good. Set to `false` to disable ops monitoring completely.
     - `config` - options passed directly into the [`Oppsy`](https://github.com/hapijs/oppsy) constructor as the `config` value. Defaults to `{}`
     - `interval` - interval used when calling `Oppsy.start()`. Defaults to `15000`.

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -7,7 +7,7 @@ const Joi = require('joi');
 exports.monitor = Joi.object().keys({
     includes: Joi.object().keys({
         request: Joi.array().items(Joi.string().valid('headers', 'payload')).default([]),
-        response: Joi.array().items(Joi.string().valid('payload')).default([])
+        response: Joi.array().items(Joi.string().valid('headers', 'payload')).default([])
     }).default({
         request: [],
         response: []

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -94,6 +94,10 @@ class RequestSent {
             this.requestPayload = request.payload;
         }
 
+        if (resOptions.headers && request.response) {
+            this.responseHeaders = request.response.headers;
+        }
+
         if (resOptions.payload && request.response) {
             this.responsePayload = request.response.source;
         }

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -476,7 +476,7 @@ describe('Monitor', () => {
             }
         });
 
-        it('provides additional information about "response" events using "requestHeaders","requestPayload", and "responsePayload"', { plan: 8 }, async () => {
+        it('provides additional information about "response" events using "requestHeaders","requestPayload", "responseHeaders" and "responsePayload"', { plan: 9 }, async () => {
 
             const server = new Hapi.Server();
 
@@ -498,7 +498,7 @@ describe('Monitor', () => {
                 },
                 includes: {
                     request: ['headers', 'payload'],
-                    response: ['payload']
+                    response: ['headers', 'payload']
                 }
             });
 
@@ -527,6 +527,7 @@ describe('Monitor', () => {
             expect(response.event).to.equal('response');
             expect(response.log).to.be.an.array();
             expect(response.headers).to.exist();
+            expect(response.responseHeaders).to.exist();
             expect(response.requestPayload).to.equal({
                 data: 'example payload'
             });


### PR DESCRIPTION
Currently, there's no way to add response headers to response events (there's currently only request headers available). This PR adds that ability. My use-case is to be able to log content-length.