### PR TITLE
Add error property to server logs

### DIFF
--- a/API.md
+++ b/API.md
@@ -151,6 +151,7 @@ Event object associated with 'log' events.
 - `timestamp` - JavaScript timestamp indicating when the 'log' event occurred.
 - `tags` - array of strings representing any tags associated with the 'log' event.
 - `data` - string or object passed via `server.log()` calls.
+- `error` - error object, replacing `data` if only an error object is passed to `server.log()`
 - `pid` - the current process id.
 
 ### `RequestError`

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,6 +23,7 @@ class ServerLog {
         this.tags = event.tags;
         this.data = event.data;
         this.pid = process.pid;
+        this.error = event.error;
     }
 }
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -177,4 +177,23 @@ describe('utils', () => {
             expect(parse.error).to.equal('An internal server error occurred');
         });
     });
+
+
+    describe('ServerLog()', () => {
+
+        it('accepts error on the event object when data is not present', { plan: 2 }, () => {
+
+            const errorInstance = new Error('This is a test');
+
+            const err = new Utils.ServerLog({
+                event: 'log',
+                timestamp: 1517592924723,
+                tags: ['log', 'error'],
+                error: errorInstance
+            });
+
+            expect(err.error).to.equal(errorInstance);
+            expect(err.data).to.be.undefined();
+        });
+    });
 });


### PR DESCRIPTION
As of Hapi17 calls to `server.log` that pass an error instances as the data will append the error to `event.error` and not `event.data`. As such this needs to be captured by good's `ServerLog` class.