### PR TITLE
Updated README.md to correct options usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ const options = {
 
 await server.register({
     plugin: require('good'),
-    options,
+    options: options,
 });
 
 await server.start();


### PR DESCRIPTION
Node: 8.5.0
hapi: 17.2.2
good: 8.1.0

When providing options to the good plugin registration as presently documented the plugin fails to register correctly (silently) with the result that nothing is logged.

I updated README.md to reflect the more reliable pattern of 'options: options'