### PR TITLE
Fix a typo in the example code

### DIFF
--- a/API.md
+++ b/API.md
@@ -104,7 +104,7 @@ Consuming the plugin config in the stream transform:
 ```js
 _transform(data, enc, next) {
 
-    if (data.eventName === 'response' && data.config.suppressResponseEvent === true) {
+    if (data.event === 'response' && data.config.suppressResponseEvent === true) {
         return next();
     }
 


### PR DESCRIPTION
In the example code _Consuming the plugin config in the stream transform_ is the `event` property of data object incorrectly accessed as `data.eventName`