### PR TITLE
match dependencies' engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "plugin"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.9.0"
   },
   "dependencies": {
     "hoek": "5.x.x",


### PR DESCRIPTION
Trying to install this with node 8.0 (current engine requirement) you'd get this
```console
error hoek@5.0.3: The engine "node" is incompatible with this module. Expected version ">=8.9.0".
```

The engine requirement in `package.json` should match the dependencies.