### PR TITLE
Allow reconfiguring after monitor is started

### DIFF
--- a/API.md
+++ b/API.md
@@ -36,6 +36,12 @@ as general events are a process-wide facility and will result in duplicated log 
     - instantiated stream objects
     - string name of a built in `process` stream. Valid values are `'stdout'` and `'stderr'`.
 
+## Plugin Interface
+
+After registering the plugin with your server instance, the following methods will be available on `server.plugins.good`.
+
+- `reconfigure(options)` - reconfigure good on the fly. This will force good to stop monitoring, close all reporter streams (including files and network connections), reload the new configuration, open new streams based on the new configuration, and start monitoring again. The `options` argument schema is identical to the one passed in on plugin registration, documented above. This is a useful way to honor 'SIGHUP' signals for supporting Linux's logrotate program to reopen files or changing logging options without restarting your server.
+
 ## Reporter Interface
 
 The reporter interface uses the standard stream-and-pipe interface found commonly in the node ecosystem. Each item in the array of streams will be piped together in the array order. Any stream described using a stream specification object will be constructed with `new` to prevent any cross contamination from one reporter to another. For example, when passing the following specification for an "ops-console" reporter:

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,13 @@ const Schema = require('./schema');
 const Monitor = require('./monitor');
 
 const internals = {
+    validateOptions(options) {
+
+        const result = Joi.validate(options, Schema.monitor);
+        Hoek.assert(!result.error, 'Invalid', 'monitorOptions', 'options', result.error);
+
+        return result.value;
+    },
     onPostStop(monitor) {
 
         return (server, h) => {
@@ -14,29 +21,39 @@ const internals = {
             return monitor.stop();
         };
     },
-    onPreStart(monitor, options) {
+    onPreStart(monitor) {
 
         return (server, h) => {
 
-            const interval = options.ops.interval;
-            monitor.startOps(interval);
+            monitor.startOps();
+        };
+    },
+    reconfigure(monitor) {
+
+        return (options) => {
+
+            monitor.stop();
+            monitor.configure(internals.validateOptions(options));
+            monitor.start();
         };
     }
 };
 
+
 exports.register = (server, options) => {
 
-    const result = Joi.validate(options, Schema.monitor);
-    Hoek.assert(!result.error, 'Invalid', 'monitorOptions', 'options', result.error);
+    // Do the initial configuration
+    const monitor = new Monitor(server, internals.validateOptions(options));
 
-    const monitor = new Monitor(server, result.value);
     server.ext([{
         type: 'onPostStop',
         method: internals.onPostStop(monitor)
     }, {
         type: 'onPreStart',
-        method: internals.onPreStart(monitor, result.value)
+        method: internals.onPreStart(monitor)
     }]);
+
+    server.expose('reconfigure', internals.reconfigure(monitor));
 
     monitor.start();
 };

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -22,10 +22,21 @@ const internals = {
 class Monitor {
     constructor(server, options) {
 
-        this.settings = options;
         this._state = { report: false };
         this._server = server;
         this._reporters = new Map();
+        this._extensionListeners = [];
+
+        this.configure(options);
+    }
+
+    configure(options) {
+
+        if (this._reporters.size > 0 || this._extensionListeners.length > 0) {
+            throw new Error(`Good must be stopped before restarting`);
+        }
+
+        this.settings = options;
 
         const reducer = (obj, value) => {
 
@@ -36,7 +47,7 @@ class Monitor {
         const reqOptions = this.settings.includes.request.reduce(reducer, {});
         const resOptions = this.settings.includes.response.reduce(reducer, {});
 
-        this._ops = this.settings.ops && new Oppsy(server, this.settings.ops.config);
+        this._ops = this.settings.ops && new Oppsy(this._server, this.settings.ops.config);
 
         // Event handlers
 
@@ -64,12 +75,11 @@ class Monitor {
 
             this.push(() => new Utils.Ops(results));
         };
-
     }
 
-    startOps(interval) {
+    startOps() {
 
-        this._ops && this._ops.start(interval);
+        this._ops && this._ops.start(this.settings.ops.interval);
     }
 
     start() {
@@ -133,25 +143,48 @@ class Monitor {
         }
 
         // Events can not be any of ['log', 'ops', 'request', 'response', 'tail']
-        for (let i = 0; i < this.settings.extensions.length; ++i) {
-            const event = this.settings.extensions[i];
-            this._server.events.on(this.settings.extensions[i], (...args) => {
+        this.settings.extensions.forEach((event) => {
 
-                const payload = {
-                    event,
-                    timestamp: Date.now(),
-                    payload: args
-                };
-                this.push(() => Object.assign({}, payload));
+            const listener = (...args) => {
+
+                this.push(() => {
+
+                    return Object.assign({}, {
+                        event,
+                        timestamp: Date.now(),
+                        payload: args
+                    });
+                });
+            };
+
+            // Store a reference to the listener so we can remove them later
+            this._extensionListeners.push({
+                event, listener
             });
-        }
+
+            this._server.events.on(event, listener);
+        });
     }
 
     stop() {
 
         this._state.report = false;
-        if (this._ops) {
 
+        // Prevent memory leaks by removing dead listeners
+        this._server.events.removeListener('log', this._logHandler);
+        this._server.events.removeListener('response', this._responseHandler);
+        // These cannot be removed because Podium does not support unsubscribing from criteria, only event names.
+        // this._server.events.removeListener({ name: 'request', channels: ['error'] }, this._errorHandler);
+        // this._server.events.removeListener({ name: 'request', channels: ['app'] }, this._requestLogHandler);
+
+        // Remove listeners for any generated extensions
+        this._extensionListeners.forEach(({ event, listener }) => {
+
+            this._server.events.removeListener(event, listener);
+        });
+        this._extensionListeners = [];
+
+        if (this._ops) {
             this._ops.stop();
             this._ops.removeAllListeners();
         }
@@ -159,6 +192,7 @@ class Monitor {
         for (const reporter of this._reporters.values()) {
             reporter.end();
         }
+        this._reporters = new Map();
     }
 
     push(value) {

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -26,6 +26,33 @@ class Monitor {
         this._server = server;
         this._reporters = new Map();
         this._extensionListeners = [];
+        this._registeredMainEvents = false;
+
+        // Event handlers
+        this._requestLogHandler = (request, event) => {
+
+            this.push(() => new Utils.RequestLog(this._reqOptions, request, event));
+        };
+
+        this._logHandler = (event) => {
+
+            this.push(() => new Utils.ServerLog(event));
+        };
+
+        this._errorHandler = (request, error) => {
+
+            this.push(() => new Utils.RequestError(this._reqOptions, request, error));
+        };
+
+        this._responseHandler = (request) => {
+
+            this.push(() => new Utils.RequestSent(this._reqOptions, this._resOptions, request, this._server));
+        };
+
+        this._opsHandler = (results) => {
+
+            this.push(() => new Utils.Ops(results));
+        };
 
         this.configure(options);
     }
@@ -44,37 +71,10 @@ class Monitor {
             return obj;
         };
 
-        const reqOptions = this.settings.includes.request.reduce(reducer, {});
-        const resOptions = this.settings.includes.response.reduce(reducer, {});
+        this._reqOptions = this.settings.includes.request.reduce(reducer, {});
+        this._resOptions = this.settings.includes.response.reduce(reducer, {});
 
         this._ops = this.settings.ops && new Oppsy(this._server, this.settings.ops.config);
-
-        // Event handlers
-
-        this._requestLogHandler = (request, event) => {
-
-            this.push(() => new Utils.RequestLog(reqOptions, request, event));
-        };
-
-        this._logHandler = (event) => {
-
-            this.push(() => new Utils.ServerLog(event));
-        };
-
-        this._errorHandler = (request, error) => {
-
-            this.push(() => new Utils.RequestError(reqOptions, request, error));
-        };
-
-        this._responseHandler = (request) => {
-
-            this.push(() => new Utils.RequestSent(reqOptions, resOptions, request, this._server));
-        };
-
-        this._opsHandler = (results) => {
-
-            this.push(() => new Utils.Ops(results));
-        };
     }
 
     startOps() {
@@ -131,11 +131,14 @@ class Monitor {
 
         this._state.report = true;
 
-        // Initialize Events
-        this._server.events.on('log', this._logHandler);
-        this._server.events.on({ name: 'request', channels: ['error'] }, this._errorHandler);
-        this._server.events.on('response', this._responseHandler);
-        this._server.events.on({ name: 'request', channels: ['app'] }, this._requestLogHandler);
+        // Initialize Events. Make sure we only do this once to prevent duplicate events.
+        if (!this._registeredMainEvents) {
+            this._server.events.on('log', this._logHandler);
+            this._server.events.on('response', this._responseHandler);
+            this._server.events.on({ name: 'request', channels: ['error'] }, this._errorHandler);
+            this._server.events.on({ name: 'request', channels: ['app'] }, this._requestLogHandler);
+            this._registeredMainEvents = true;
+        }
 
         if (this._ops) {
             this._ops.on('ops', this._opsHandler);
@@ -169,13 +172,6 @@ class Monitor {
     stop() {
 
         this._state.report = false;
-
-        // Prevent memory leaks by removing dead listeners
-        this._server.events.removeListener('log', this._logHandler);
-        this._server.events.removeListener('response', this._responseHandler);
-        // These cannot be removed because Podium does not support unsubscribing from criteria, only event names.
-        // this._server.events.removeListener({ name: 'request', channels: ['error'] }, this._errorHandler);
-        // this._server.events.removeListener({ name: 'request', channels: ['app'] }, this._requestLogHandler);
 
         // Remove listeners for any generated extensions
         this._extensionListeners.forEach(({ event, listener }) => {

--- a/test/index.js
+++ b/test/index.js
@@ -150,4 +150,32 @@ describe('good', () => {
             expect(err).to.be.an.error('Invalid monitorOptions options child "extensions" fails because ["extensions" at position 0 fails because ["0" contains an invalid value]]');
         }
     });
+
+    describe('reconfigure()', () => {
+
+        it('exposes reconfigure on server.plugins.good', async () => {
+
+            const server = new Hapi.Server();
+            await server.register(Good);
+            expect(server.plugins.good.reconfigure).to.be.a.function();
+        });
+
+        it('reconfigures and restarts the monitor', async () => {
+
+            const server = new Hapi.Server();
+            await server.register(Good);
+            server.plugins.good.reconfigure({
+                reporters: {
+                    foo: [
+                        new GoodReporter.Incrementer(2),
+                        new GoodReporter.Incrementer(4), {
+                            module: '../test/fixtures/reporters',
+                            name: 'Writer',
+                            args: [{ objectMode: true }]
+                        }
+                    ]
+                }
+            });
+        });
+    });
 });

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -407,7 +407,7 @@ describe('Monitor', () => {
             expect(two._finalized).to.be.true();
             expect(three._finalized).to.be.true();
             expect(monitor._state.report).to.be.false();
-            expect([false, null]).to.contain(monitor._ops._interval._repeat);
+            expect(monitor._ops._interval._idleTimeout).to.equal(-1);
         });
 
         it('removes listeners from server', () => {


### PR DESCRIPTION
This allows consumer apps to reconfigure and restart good's monitor on the fly. This is useful for supporting logrotate (allows our application to handle SIGHUP signals to trigger reopening of files) and supporting on-the-fly configuration changes.

We're using this in https://github.com/elastic/kibana and think it's a useful addition to all users of good. I've included updated tests and documentation. Happy to take feedback and tweaks!