### PR TITLE
Update package scope in documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -45,11 +45,11 @@ The reporter interface uses the standard stream-and-pipe interface found commonl
 ```js
 {
     'ops-console': [{
-        module: 'good-squeeze',
+        module: '@hapi/good-squeeze',
         name: 'Squeeze',
         args: [{ ops: '*' }]
     }, {
-        module: 'good-squeeze',
+        module: '@hapi/good-squeeze',
         name: 'SafeJson'
     }, 'stdout']
 }

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ const options = {
     reporters: {
         myConsoleReporter: [
             {
-                module: 'good-squeeze',
+                module: '@hapi/good-squeeze',
                 name: 'Squeeze',
                 args: [{ log: '*', response: '*' }]
             },
             {
-                module: 'good-console'
+                module: '@hapi/good-console'
             },
             'stdout'
         ]
@@ -35,7 +35,7 @@ const options = {
 };
 
 await server.register({
-    plugin: require('good'),
+    plugin: require('@hapi/good'),
     options,
 });
 

--- a/examples/log-to-console.md
+++ b/examples/log-to-console.md
@@ -4,21 +4,21 @@
 
 ```
 console: [{
-    module: 'good-squeeze',
+    module: '@hapi/good-squeeze',
     name: 'Squeeze',
     args: [{
         log: '*',
         response: '*'
     }]
 }, {
-    module: 'good-console'
+    module: '@hapi/good-console'
 }, 'stdout']
 ```
 
 This reporter spec logs response and log events to the console.
 
-It uses `good-squeeze` to select only log and response events.
+It uses `@hapi/good-squeeze` to select only log and response events.
 
-Events that pass the filter stream to `good-console` for formatting. See the `good console` [constructor docs](https://github.com/hapijs/good-console#new-goodconsoleconfig) for details on `args` values.
+Events that pass the filter stream to `@hapi/good-console` for formatting. See the `good console` [constructor docs](https://github.com/hapijs/good-console#new-goodconsoleconfig) for details on `args` values.
 
 Formatted events stream to `process.stdout` for display.


### PR DESCRIPTION
* **Problem:** Some packages in documentation don't have the updated `@hapi` scope
* **Solution:** Update the docs!
* **Testing:** n/a