### PR TITLE
fix: plugins should be searched for in the caller deps

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -97,7 +97,7 @@ module.exports = internals.Monitor = class {
 
                 const isFn = typeof spec.module === 'function';
                 const moduleName = isFn ? spec.module.name || `The unnamed module at position ${i}` : spec.module;
-                let Ctor = isFn ? spec.module : require(spec.module);
+                let Ctor = isFn ? spec.module : require(require.resolve(spec.module, {paths: [require.main.filename]}));
                 Ctor = spec.name ? Ctor[spec.name] : Ctor;
                 Hoek.assert(typeof Ctor === 'function', `Error in ${reporterName}. ${moduleName} must be a constructor function.`);
 

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -97,7 +97,7 @@ module.exports = internals.Monitor = class {
 
                 const isFn = typeof spec.module === 'function';
                 const moduleName = isFn ? spec.module.name || `The unnamed module at position ${i}` : spec.module;
-                let Ctor = isFn ? spec.module : require(require.resolve(spec.module, {paths: [require.main.filename]}));
+                let Ctor = isFn ? spec.module : require(require.resolve(spec.module, { paths: [require.main.filename] }));
                 Ctor = spec.name ? Ctor[spec.name] : Ctor;
                 Hoek.assert(typeof Ctor === 'function', `Error in ${reporterName}. ${moduleName} must be a constructor function.`);
 


### PR DESCRIPTION
This fixes https://github.com/pnpm/pnpm/issues/1963

`@hapi/good` should search for plugins in the dependent project's
node_modules.