### PR TITLE
Fix CI and switch to GitHub Actions

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -1,0 +1,30 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, windows, macos]
+        node: ['*', '14', '12']
+        hapi: ['20', '19']
+
+    runs-on: ${{ matrix.os }}-latest
+    name: ${{ matrix.os }} node@${{ matrix.node }} hapi@${{ matrix.hapi }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: install
+        run: npm install
+      - name: install hapi
+        run: npm install @hapi/hapi@${{ matrix.hapi }}
+      - name: test
+        run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-version: ~> 1.0
-
-
-import:
-  - hapijs/ci-config-travis:node_js.yml@main
-  - hapijs/ci-config-travis:install_plugin.yml@main
-  - hapijs/ci-config-travis:os.yml@main
-  - hapijs/ci-config-travis:env.yml@main

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -939,11 +939,11 @@ describe('Monitor', () => {
 
             const write = process.stdout.write;
             const writeData = [];
-            process.stdout.write = replace(write, writeData);
+            process.stdout.write = replace(write.bind(process.stdout), writeData);
 
             const err = process.stderr.write;
             const errData = [];
-            process.stderr.write = replace(err, errData);
+            process.stderr.write = replace(err.bind(process.stderr), errData);
 
             const server = new Hapi.Server();
             const monitor = internals.monitorFactory(server, {

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -532,7 +532,7 @@ describe('Monitor', () => {
                     foo: [new Reporters.Namer('ops'), out]
                 },
                 ops: {
-                    interval: 100
+                    interval: 1000
                 }
             });
 
@@ -541,10 +541,10 @@ describe('Monitor', () => {
 
             monitor.start();
 
-            monitor.startOps(100);
+            monitor.startOps(1000);
 
             // Give the reporters time to report
-            await Hoek.wait(150);
+            await Hoek.wait(1500);
 
             expect(out.data).to.have.length(1);
 
@@ -960,7 +960,7 @@ describe('Monitor', () => {
 
             monitor.startOps(100);
 
-            await Hoek.wait(250);
+            await Hoek.wait(500);
 
             monitor.stop();
 


### PR DESCRIPTION
I noticed that #639 was opened recently to switch from Travis CI to GitHub Actions. I can see that it's not merged and I assume it's because CI is currently failing. I've looked into it and it seems to be a series of race-conditions which means that under certain constrained environments (especially CI containers), the tests run their assertions before the tested code have completed running. This PR includes everything from #639 + a few fixes to make CI stable by increasing the test-wait-times. This is obviously not a very nice solution, but it's the solution that the current test-suite employs, so without rewriting everything, this is what I came up with.

